### PR TITLE
Use Url::to() to create URL

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -407,7 +407,7 @@ class User extends ActiveRecord implements IdentityInterface
             return null;
         }
 
-        return Url::toRoute(['/user/registration/confirm', 'id' => $this->id, 'token' => $this->confirmation_token], true);
+        return Url::to(['/user/registration/confirm', 'id' => $this->id, 'token' => $this->confirmation_token], true);
     }
 
     /**
@@ -462,7 +462,7 @@ class User extends ActiveRecord implements IdentityInterface
      */
     public function getRecoveryUrl()
     {
-        return Url::toRoute(['/user/recovery/reset',
+        return Url::to(['/user/recovery/reset',
             'id' => $this->id,
             'token' => $this->recovery_token
         ], true);


### PR DESCRIPTION
Using Url::toRoute method causes problems with the rules for creating url, not respecting the prefix.
