### PR TITLE
Setting the URL prefix.

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -46,8 +46,8 @@ class Bootstrap implements BootstrapInterface
                 'identityClass' => $identityClass
             ]);
 
-            $app->get('urlManager')->rules[] = new GroupUrlRule([
-                'prefix' => 'user',
+            $configUrlRule = [
+                'prefix' => $app->getModule('user')->urlPrefix,
                 'rules' => [
                     '<id:\d+>' => 'profile/show',
                     '<action:(login|logout)>' => 'security/<action>',
@@ -57,7 +57,13 @@ class Bootstrap implements BootstrapInterface
                     'recover/<id:\d+>/<token:\w+>' => 'recovery/reset',
                     'settings/<action:\w+>' => 'settings/<action>'
                 ]
-            ]);
+            ];
+
+            if ($app->getModule('user')->urlPrefix != 'user') {
+                $configUrlRule['routePrefix'] = 'user';
+            }
+
+            $app->get('urlManager')->rules[] = new GroupUrlRule($configUrlRule);
 
             if (!$app->has('authClientCollection')) {
                 $app->set('authClientCollection', [

--- a/Module.php
+++ b/Module.php
@@ -66,6 +66,12 @@ class Module extends BaseModule
     public $admins = [];
 
     /**
+     * @var string The prefix for user module URL.
+     * @See [[GroupUrlRule::prefix]]
+     */
+    public $urlPrefix = 'user';
+
+    /**
      * @inheritdoc
      */
     public function __construct($id, $parent = null, $config = [])


### PR DESCRIPTION
Allows use other names for the module. 
For example:
`http://mydomain.com/u/login`
`http://mydomain.com/whatever/forgot`
