### PR TITLE
Set registration_ip on create new user

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -344,7 +344,7 @@ class User extends ActiveRecord implements IdentityInterface
     {
         if ($insert) {
             $this->setAttribute('auth_key', \Yii::$app->security->generateRandomString());
-            if (Yii::$app instanceof \yii\web\Application) {
+            if (\Yii::$app instanceof \yii\web\Application) {
                 $this->setAttribute('registration_ip', ip2long(Yii::$app->request->userIP));
             }
         }


### PR DESCRIPTION
It seems that the field is not filled at all. I could not find where it is set...
