### PR TITLE
Interrupts the execution only when there is an error in the validation.

### DIFF
--- a/controllers/SecurityController.php
+++ b/controllers/SecurityController.php
@@ -145,9 +145,9 @@ class SecurityController extends Controller
      */
     protected function performAjaxValidation(Model $model)
     {
-        if (\Yii::$app->request->isAjax && $model->load(\Yii::$app->request->post())) {
+        if (\Yii::$app->request->isAjax && $model->load(\Yii::$app->request->post()) && $error = ActiveForm::validate($model)) {
             \Yii::$app->response->format = Response::FORMAT_JSON;
-            echo json_encode(ActiveForm::validate($model));
+            echo json_encode($error);
             \Yii::$app->end();
         }
     }


### PR DESCRIPTION
In fact, contrary to what you said in the post https://github.com/dektrium/yii2-user/pull/218#issuecomment-68593216, the execution is always interrupted when the method is run, due to the command 
```PHP
\Yii::$app->end();
```

This change I'm suggesting is that the flow is interrupted only when there is an error in the validation.