### PR TITLE
Bugfix: Tried to delete an non existing token

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -302,20 +302,21 @@ class User extends ActiveRecord implements IdentityInterface
 
         if ($token === null || $token->isExpired) {
             \Yii::$app->session->setFlash('danger', \Yii::t('user', 'Confirmation link is invalid or out-of-date. You can try requesting a new one.'));
-        }
-
-        $token->delete();
-
-        $this->confirmed_at = time();
-
-        \Yii::$app->user->login($this);
-
-        \Yii::getLogger()->log('User has been confirmed', Logger::LEVEL_INFO);
-
-        if ($this->save(false)) {
-            \Yii::$app->session->setFlash('success', \Yii::t('user', 'Your account has been successfully confirmed.'));
         } else {
-            \Yii::$app->session->setFlash('danger', \Yii::t('user', 'Something went wrong and your account has not been confirmed.'));
+    
+            $token->delete();
+    
+            $this->confirmed_at = time();
+    
+            \Yii::$app->user->login($this);
+    
+            \Yii::getLogger()->log('User has been confirmed', Logger::LEVEL_INFO);
+    
+            if ($this->save(false)) {
+                \Yii::$app->session->setFlash('success', \Yii::t('user', 'Your account has been successfully confirmed.'));
+            } else {
+                \Yii::$app->session->setFlash('danger', \Yii::t('user', 'Something went wrong and your account has not been confirmed.'));
+            }
         }
     }
 


### PR DESCRIPTION
When trying to confirm an email address with an invalid token it would render an error. It would also show a message saying the account has been successfully confirmed together with the message that the confirmation link is invalid or out-of-date.
I put everything in an else statement to prevent deleting non existing tokens or trying to log in a user with an invalid token.

I have not written any extra test for this as the test already check if
$I->see('Confirmation link is invalid or out-of-date. You can try requesting a new one.');