### PR TITLE
redirect failed on actionConfirm()

### DIFF
--- a/controllers/SettingsController.php
+++ b/controllers/SettingsController.php
@@ -145,7 +145,7 @@ class SettingsController extends Controller
 
         $user->attemptEmailChange($code);
 
-        return $this->redirect('account');
+        return $this->redirect(['account']);
     }
 
     /**


### PR DESCRIPTION
redirection went to /account and should take care of the current route.
the reason was missing brackets around 'account'
pls integrate into the next version.
thx.