### PR TITLE
Corrected link to social networks settings page in doc

### DIFF
--- a/docs/available-actions.md
+++ b/docs/available-actions.md
@@ -16,6 +16,6 @@ helper `\yii\helpers\Url::to()`.
 |**/user/recovery/reset**       | Displays password reset form (requires *id* and *token* query params) |
 |**/user/settings/profile**     | Displays profile settings form                                        |
 |**/user/settings/account**     | Displays account settings form (email, username, password)            |
-|**/user/settings/networks**    | Displays social networks settings page                                |
+|**/user/settings/networks**    | Displays social network accounts settings page                        |
 |**/user/profile/show**         | Displays user's profile (requires *id* query param)                   |
 |**/user/admin/index**          | Displays user management interface                                    |

--- a/docs/available-actions.md
+++ b/docs/available-actions.md
@@ -16,6 +16,6 @@ helper `\yii\helpers\Url::to()`.
 |**/user/recovery/reset**       | Displays password reset form (requires *id* and *token* query params) |
 |**/user/settings/profile**     | Displays profile settings form                                        |
 |**/user/settings/account**     | Displays account settings form (email, username, password)            |
-|**/user/settings/accounts**    | Displays social accounts settings page                                |
+|**/user/settings/networks**    | Displays social networks settings page                                |
 |**/user/profile/show**         | Displays user's profile (requires *id* query param)                   |
 |**/user/admin/index**          | Displays user management interface                                    |


### PR DESCRIPTION
Apparently it used to be `/user/settings/accounts`, but now it is `/user/settings/networks`