### PR TITLE
Update username pattern

### DIFF
--- a/models/RegistrationForm.php
+++ b/models/RegistrationForm.php
@@ -51,7 +51,7 @@ class RegistrationForm extends Model
     {
         return [
             ['username', 'filter', 'filter' => 'trim'],
-            ['username', 'match', 'pattern' => '/^[a-zA-Z0-9_\.-@]+$/'],
+            ['username', 'match', 'pattern' => '/^[-a-zA-Z0-9_\.@]+$/'],
             ['username', 'required'],
             ['username', 'unique', 'targetClass' => $this->module->modelMap['User'],
                 'message' => \Yii::t('user', 'This username has already been taken')],

--- a/models/RegistrationForm.php
+++ b/models/RegistrationForm.php
@@ -51,7 +51,7 @@ class RegistrationForm extends Model
     {
         return [
             ['username', 'filter', 'filter' => 'trim'],
-            ['username', 'match', 'pattern' => '/^[a-zA-Z]\w+$/'],
+            ['username', 'match', 'pattern' => '/^[a-zA-Z0-9_\.-@]+$/'],
             ['username', 'required'],
             ['username', 'unique', 'targetClass' => $this->module->modelMap['User'],
                 'message' => \Yii::t('user', 'This username has already been taken')],

--- a/models/SettingsForm.php
+++ b/models/SettingsForm.php
@@ -75,7 +75,7 @@ class SettingsForm extends Model
         return [
             [['username', 'email', 'current_password'], 'required'],
             [['username', 'email'], 'filter', 'filter' => 'trim'],
-            ['username', 'match', 'pattern' => '/^[a-zA-Z0-9_\.-@]+$/'],
+            ['username', 'match', 'pattern' => '/^[-a-zA-Z0-9_\.@]+$/'],
             ['username', 'string', 'min' => 3, 'max' => 20],
             ['email', 'email'],
             [['email', 'username'], 'unique', 'when' => function ($model, $attribute) {

--- a/models/SettingsForm.php
+++ b/models/SettingsForm.php
@@ -75,7 +75,7 @@ class SettingsForm extends Model
         return [
             [['username', 'email', 'current_password'], 'required'],
             [['username', 'email'], 'filter', 'filter' => 'trim'],
-            ['username', 'match', 'pattern' => '/^[a-zA-Z]\w+$/'],
+            ['username', 'match', 'pattern' => '/^[a-zA-Z0-9_\.-@]+$/'],
             ['username', 'string', 'min' => 3, 'max' => 20],
             ['email', 'email'],
             [['email', 'username'], 'unique', 'when' => function ($model, $attribute) {

--- a/models/User.php
+++ b/models/User.php
@@ -176,7 +176,7 @@ class User extends ActiveRecord implements IdentityInterface
         return [
             // username rules
             ['username', 'required', 'on' => ['register', 'connect', 'create', 'update']],
-            ['username', 'match', 'pattern' => '/^[a-zA-Z0-9_\.-@]+$/'],
+            ['username', 'match', 'pattern' => '/^[-a-zA-Z0-9_\.@]+$/'],
             ['username', 'string', 'min' => 3, 'max' => 25],
             ['username', 'unique'],
             ['username', 'trim'],

--- a/models/User.php
+++ b/models/User.php
@@ -176,7 +176,7 @@ class User extends ActiveRecord implements IdentityInterface
         return [
             // username rules
             ['username', 'required', 'on' => ['register', 'connect', 'create', 'update']],
-            ['username', 'match', 'pattern' => '/^[a-zA-Z]\w+$/'],
+            ['username', 'match', 'pattern' => '/^[a-zA-Z0-9_\.-@]+$/'],
             ['username', 'string', 'min' => 3, 'max' => 25],
             ['username', 'unique'],
             ['username', 'trim'],


### PR DESCRIPTION
I suggest update the username pattern to make it more suitable to reality.

- Do not allow special characters.
- Allow start with a number. This prohibition is very restrictive.

In a project work, the username is formed only by numbers, the registration code of the employee.