### PR TITLE
Fix small bug in User Administration. Confirmation time not created time

### DIFF
--- a/views/admin/_info.php
+++ b/views/admin/_info.php
@@ -31,7 +31,7 @@
         <tr>
             <td><strong><?= Yii::t('user', 'Confirmation status') ?>:</strong></td>
             <?php if ($user->isConfirmed): ?>
-            <td class="text-success"><?= Yii::t('user', 'Confirmed at {0, date, MMMM dd, YYYY HH:mm}', [$user->created_at]) ?></td>
+            <td class="text-success"><?= Yii::t('user', 'Confirmed at {0, date, MMMM dd, YYYY HH:mm}', [$user->confirmed_at]) ?></td>
             <?php else: ?>
             <td class="text-danger"><?= Yii::t('user', 'Unconfirmed') ?></td>
             <?php endif ?>


### PR DESCRIPTION
fix for issue  #361

the confirmation time was actually showing the creation time.