### PR TITLE
Do not limit user->username length to 25 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `enh` Regenerate `auth_key` after blocking the user (dmeroff)
 - `enh` Improved registration process #236 (dmeroff)
 - `fix` Fixed display of confirmation time #361 (pedros80)
+- `fix` Do not limit username length to 25 chars #369 (thyseus)
 
 ## 0.9.4 [6 April 2015]
 

--- a/migrations/m141222_135246_alter_username_length.php
+++ b/migrations/m141222_135246_alter_username_length.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Dektrium project.
+ *
+ * (c) Dektrium project <http://github.com/dektrium/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use yii\db\Query;
+use yii\db\Schema;
+use yii\db\Migration;
+
+class m141222_135246_alter_username_length extends Migration
+{
+    public function up()
+    {
+        $this->alterColumn('{{%user}}', 'username', Schema::TYPE_STRING.'(255)');
+    }
+
+    public function down()
+    {
+        $this->alterColumn('{{%user}}', 'username', Schema::TYPE_STRING.'(25)');
+    }
+}

--- a/models/RegistrationForm.php
+++ b/models/RegistrationForm.php
@@ -57,7 +57,7 @@ class RegistrationForm extends Model
         $user = $this->module->modelMap['User'];
         return [
             // username rules
-            'usernameLength'   => ['username', 'string', 'min' => 3, 'max' => 20],
+            'usernameLength'   => ['username', 'string', 'min' => 3, 'max' => 255],
             'usernameTrim'     => ['username', 'filter', 'filter' => 'trim'],
             'usernamePattern'  => ['username', 'match', 'pattern' => $user::$usernameRegexp],
             'usernameRequired' => ['username', 'required'],

--- a/models/User.php
+++ b/models/User.php
@@ -196,7 +196,7 @@ class User extends ActiveRecord implements IdentityInterface
             // username rules
             'usernameRequired' => ['username', 'required', 'on' => ['register', 'create', 'connect', 'update']],
             'usernameMatch'    => ['username', 'match', 'pattern' => static::$usernameRegexp],
-            'usernameLength'   => ['username', 'string', 'min' => 3, 'max' => 25],
+            'usernameLength'   => ['username', 'string', 'min' => 3, 'max' => 255],
             'usernameUnique'   => ['username', 'unique', 'message' => \Yii::t('user', 'This username has already been taken')],
             'usernameTrim'     => ['username', 'trim'],
 

--- a/tests/codeception/unit/RegistrationFormTest.php
+++ b/tests/codeception/unit/RegistrationFormTest.php
@@ -35,7 +35,8 @@ class RegistrationFormTest extends TestCase
         $this->model = new RegistrationForm();
 
         verify('username is required', $this->model->validate(['username']))->false();
-        $this->model->username = \Yii::$app->security->generateRandomKey();
+        $toolongstring = function() { $string = ''; for($i = 0; $i <= 256; $i++) $string .= 'X'; return $string; };
+        $this->model->username = $toolongstring();
         verify('username is too long', $this->model->validate(['username']))->false();
         $this->model->username = '!@# абв';
         verify('username contains invalid characters', $this->model->validate(['username']))->false();

--- a/views/admin/_user.php
+++ b/views/admin/_user.php
@@ -16,5 +16,5 @@
 ?>
 
 <?= $form->field($user, 'email')->textInput(['maxlength' => 255]) ?>
-<?= $form->field($user, 'username')->textInput(['maxlength' => 25]) ?>
+<?= $form->field($user, 'username')->textInput(['maxlength' => 255]) ?>
 <?= $form->field($user, 'password')->passwordInput() ?>


### PR DESCRIPTION
A project i have done needed registration by email only,
so i have written every email into the username field.
This worked well, but the username field looks ugly with
all the emails truncated after char 25

I do not see the sense in limiting the username length.

Some people use longer usernames, and modern applications
should display them properly. Please consider to remote
the username character length limit.