### PR TITLE
Ensure user/index works without php-intl extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `enh` Regenerate `auth_key` after blocking the user (dmeroff)
 - `enh` Improved registration process #236 (dmeroff)
+- `fix` Ensure user/index works without php-intl extension #370 (thyseus)
 - `fix` Fixed display of confirmation time #361 (pedros80)
 
 ## 0.9.4 [6 April 2015]

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -54,7 +54,10 @@ $this->params['breadcrumbs'][] = $this->title;
         [
             'attribute' => 'created_at',
             'value' => function ($model) {
+              if (extension_loaded('intl'))
                 return Yii::t('user', '{0, date, MMMM dd, YYYY HH:mm}', [$model->created_at]);
+              else
+                return date('Y-m-d G:i:s', $model->created_at);
             },
             'filter' => DatePicker::widget([
                 'model'      => $searchModel,


### PR DESCRIPTION
Not having the php-intl extension installed yields this error:

Not Supported – yii\base\NotSupportedException

Message format 'date' is not supported. You have to install PHP intl extension to use this feature.

This is a fallback for user not having installed this extension.