### PR TITLE
Exclude vendor dir from messages

### DIFF
--- a/messages/message.php
+++ b/messages/message.php
@@ -39,7 +39,7 @@ return [
         '.hgkeep',
         '/messages',
         '/tests',
-        '/vendor'
+        '/vendor',
     ],
     'format' => 'php',
 ];

--- a/messages/message.php
+++ b/messages/message.php
@@ -39,6 +39,7 @@ return [
         '.hgkeep',
         '/messages',
         '/tests',
+        '/vendor'
     ],
     'format' => 'php',
 ];


### PR DESCRIPTION
If you do a composer install and run: vendor/bin/yii message/extract messages/message.php
It will also translate the vendor folder.