### PR TITLE
Migration - don't force charset and collate in mysql

### DIFF
--- a/migrations/Migration.php
+++ b/migrations/Migration.php
@@ -29,11 +29,9 @@ class Migration extends \yii\db\Migration
     public function init()
     {
         parent::init();
-
+		
         switch (Yii::$app->db->driverName) {
             case 'mysql':
-                $this->tableOptions = 'CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE=InnoDB';
-                break;
             case 'pgsql':
                 $this->tableOptions = null;
                 break;


### PR DESCRIPTION
The collate was set to `utf8_general_ci` but many developers uses `utf8_unicode_ci`.
I left `$tableOptions` property of `Migration` class to be null so tables charset and collate will be set to db default values.

I didn't remove the property in case someone wanted to set it different than db default.

Refs #443 