### PR TITLE
Cannot declare class app\filters\AccessRule

### DIFF
--- a/docs/custom-access-control.md
+++ b/docs/custom-access-control.md
@@ -15,9 +15,7 @@ Let's create new file under `@app/filters` named
 
 namespace app\filters;
 
-use yii\filters\AccessRule;
-
-class AccessRule extends AccessRule
+class AccessRule extends \yii\filters\AccessRule
 {
 
     /** @inheritdoc */


### PR DESCRIPTION
PHP Compile Error – yii\base\ErrorException
Cannot declare class app\filters\AccessRule because the name is already in use

php-fpm 5.5.9