### PR TITLE
Fix scenarios in User and RecoveryForm

### DIFF
--- a/models/RecoveryForm.php
+++ b/models/RecoveryForm.php
@@ -68,10 +68,11 @@ class RecoveryForm extends Model
     /** @inheritdoc */
     public function scenarios()
     {
-        return [
+        $scenarios = parent::scenarios();
+        return ArrayHelper::merge($scenarios, [
             'request' => ['email'],
             'reset'   => ['password'],
-        ];
+        ]);
     }
 
     /** @inheritdoc */

--- a/models/User.php
+++ b/models/User.php
@@ -181,13 +181,14 @@ class User extends ActiveRecord implements IdentityInterface
     /** @inheritdoc */
     public function scenarios()
     {
-        return [
+        $scenarios = parent::scenarios();
+        return ArrayHelper::merge($scenarios, [
             'register' => ['username', 'email', 'password'],
             'connect'  => ['username', 'email'],
             'create'   => ['username', 'email', 'password'],
             'update'   => ['username', 'email', 'password'],
             'settings' => ['username', 'email', 'password'],
-        ];
+        ]);
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
Without calling parent::scenarios we lose scenario default and have problems then redeclare class User.