### PR TITLE
Use getters instead of references to dependencies.

### DIFF
--- a/models/Account.php
+++ b/models/Account.php
@@ -15,6 +15,7 @@ use dektrium\user\clients\ClientInterface;
 use dektrium\user\Finder;
 use dektrium\user\models\query\AccountQuery;
 use dektrium\user\Module;
+use dektrium\user\traits\ModuleTrait;
 use Yii;
 use yii\authclient\ClientInterface as BaseClientInterface;
 use yii\db\ActiveRecord;
@@ -38,20 +39,13 @@ use yii\helpers\Url;
  */
 class Account extends ActiveRecord
 {
-    /** @var Module */
-    protected $module;
+    use ModuleTrait;
 
     /** @var Finder */
     protected static $finder;
 
     /** @var */
     private $_data;
-
-    /** @inheritdoc */
-    public function init()
-    {
-        $this->module = Yii::$app->getModule('user');
-    }
 
     /** @inheritdoc */
     public static function tableName()

--- a/models/LoginForm.php
+++ b/models/LoginForm.php
@@ -15,6 +15,7 @@ use dektrium\user\Finder;
 use dektrium\user\helpers\Password;
 use Yii;
 use yii\base\Model;
+use dektrium\user\traits\ModuleTrait;
 
 /**
  * LoginForm get user's login and password, validates them and logs the user in. If user has been blocked, it adds

--- a/models/LoginForm.php
+++ b/models/LoginForm.php
@@ -24,6 +24,8 @@ use yii\base\Model;
  */
 class LoginForm extends Model
 {
+    use ModuleTrait;
+
     /** @var string User's email or username */
     public $login;
 
@@ -36,9 +38,6 @@ class LoginForm extends Model
     /** @var \dektrium\user\models\User */
     protected $user;
 
-    /** @var \dektrium\user\Module */
-    protected $module;
-
     /** @var Finder */
     protected $finder;
 
@@ -49,7 +48,6 @@ class LoginForm extends Model
     public function __construct(Finder $finder, $config = [])
     {
         $this->finder = $finder;
-        $this->module = Yii::$app->getModule('user');
         parent::__construct($config);
     }
 

--- a/models/Profile.php
+++ b/models/Profile.php
@@ -11,6 +11,7 @@
 
 namespace dektrium\user\models;
 
+use dektrium\user\traits\ModuleTrait;
 use Yii;
 use yii\db\ActiveRecord;
 
@@ -31,14 +32,7 @@ use yii\db\ActiveRecord;
  */
 class Profile extends ActiveRecord
 {
-    /** @var \dektrium\user\Module */
-    protected $module;
-
-    /** @inheritdoc */
-    public function init()
-    {
-        $this->module = Yii::$app->getModule('user');
-    }
+    use ModuleTrait;
 
     /** @inheritdoc */
     public static function tableName()

--- a/models/RecoveryForm.php
+++ b/models/RecoveryForm.php
@@ -13,6 +13,7 @@ namespace dektrium\user\models;
 
 use dektrium\user\Finder;
 use dektrium\user\Mailer;
+use dektrium\user\traits\ModuleTrait;
 use Yii;
 use yii\base\Model;
 

--- a/models/RecoveryForm.php
+++ b/models/RecoveryForm.php
@@ -25,6 +25,7 @@ use yii\base\Model;
  */
 class RecoveryForm extends Model
 {
+    use ModuleTrait;
     /** @var string */
     public $email;
 
@@ -33,9 +34,6 @@ class RecoveryForm extends Model
 
     /** @var User */
     protected $user;
-
-    /** @var \dektrium\user\Module */
-    protected $module;
 
     /** @var Mailer */
     protected $mailer;
@@ -50,7 +48,6 @@ class RecoveryForm extends Model
      */
     public function __construct(Mailer $mailer, Finder $finder, $config = [])
     {
-        $this->module = Yii::$app->getModule('user');
         $this->mailer = $mailer;
         $this->finder = $finder;
         parent::__construct($config);

--- a/models/RegistrationForm.php
+++ b/models/RegistrationForm.php
@@ -22,6 +22,7 @@ use yii\base\Model;
  */
 class RegistrationForm extends Model
 {
+    use ModuleTrait;
     /**
      * @var string User email address
      */
@@ -36,19 +37,6 @@ class RegistrationForm extends Model
      * @var string Password
      */
     public $password;
-
-    /**
-     * @var Module
-     */
-    protected $module;
-
-    /**
-     * @inheritdoc
-     */
-    public function init()
-    {
-        $this->module = Yii::$app->getModule('user');
-    }
 
     /**
      * @inheritdoc

--- a/models/RegistrationForm.php
+++ b/models/RegistrationForm.php
@@ -11,7 +11,7 @@
 
 namespace dektrium\user\models;
 
-use dektrium\user\Module;
+use dektrium\user\traits\ModuleTrait;
 use Yii;
 use yii\base\Model;
 

--- a/models/ResendForm.php
+++ b/models/ResendForm.php
@@ -26,14 +26,12 @@ use yii\base\Model;
  */
 class ResendForm extends Model
 {
+    use ModuleTrait;
     /** @var string */
     public $email;
 
     /** @var User */
     private $_user;
-
-    /** @var \dektrium\user\Module */
-    protected $module;
 
     /** @var Mailer */
     protected $mailer;
@@ -48,7 +46,6 @@ class ResendForm extends Model
      */
     public function __construct(Mailer $mailer, Finder $finder, $config = [])
     {
-        $this->module = Yii::$app->getModule('user');
         $this->mailer = $mailer;
         $this->finder = $finder;
         parent::__construct($config);

--- a/models/ResendForm.php
+++ b/models/ResendForm.php
@@ -13,6 +13,7 @@ namespace dektrium\user\models;
 
 use dektrium\user\Finder;
 use dektrium\user\Mailer;
+use dektrium\user\traits\ModuleTrait;
 use Yii;
 use yii\base\Model;
 

--- a/models/SettingsForm.php
+++ b/models/SettingsForm.php
@@ -14,6 +14,7 @@ namespace dektrium\user\models;
 use dektrium\user\helpers\Password;
 use dektrium\user\Mailer;
 use dektrium\user\Module;
+use dektrium\user\traits\ModuleTrait;
 use Yii;
 use yii\base\Model;
 

--- a/models/SettingsForm.php
+++ b/models/SettingsForm.php
@@ -26,6 +26,8 @@ use yii\base\Model;
  */
 class SettingsForm extends Model
 {
+    use ModuleTrait;
+
     /** @var string */
     public $email;
 
@@ -37,9 +39,6 @@ class SettingsForm extends Model
 
     /** @var string */
     public $current_password;
-
-    /** @var Module */
-    protected $module;
 
     /** @var Mailer */
     protected $mailer;
@@ -61,7 +60,6 @@ class SettingsForm extends Model
     public function __construct(Mailer $mailer, $config = [])
     {
         $this->mailer = $mailer;
-        $this->module = Yii::$app->getModule('user');
         $this->setAttributes([
             'username' => $this->user->username,
             'email'    => $this->user->unconfirmed_email ?: $this->user->email,

--- a/models/Token.php
+++ b/models/Token.php
@@ -10,7 +10,7 @@
  */
 
 namespace dektrium\user\models;
-
+use dektrium\user\traits\ModuleTrait;
 use Yii;
 use yii\db\ActiveRecord;
 use yii\helpers\Url;
@@ -30,19 +30,12 @@ use yii\helpers\Url;
  */
 class Token extends ActiveRecord
 {
+    use ModuleTrait;
+
     const TYPE_CONFIRMATION      = 0;
     const TYPE_RECOVERY          = 1;
     const TYPE_CONFIRM_NEW_EMAIL = 2;
     const TYPE_CONFIRM_OLD_EMAIL = 3;
-
-    /** @var \dektrium\user\Module */
-    protected $module;
-
-    /** @inheritdoc */
-    public function init()
-    {
-        $this->module = Yii::$app->getModule('user');
-    }
 
     /**
      * @return \yii\db\ActiveQuery

--- a/models/User.php
+++ b/models/User.php
@@ -48,6 +48,8 @@ use yii\web\IdentityInterface;
  * @property Account[] $accounts
  * @property Profile   $profile
  *
+ * Dependencies:
+ *
  * @author Dmitry Erofeev <dmeroff@gmail.com>
  */
 class User extends ActiveRecord implements IdentityInterface
@@ -64,28 +66,22 @@ class User extends ActiveRecord implements IdentityInterface
     /** @var string Plain password. Used for model validation. */
     public $password;
 
-    /** @var \dektrium\user\Module */
-    protected $module;
-
-    /** @var Mailer */
-    protected $mailer;
-
-    /** @var Finder */
-    protected $finder;
-
     /** @var Profile|null */
     private $_profile;
 
     /** @var string Default username regexp */
     public static $usernameRegexp = '/^[-a-zA-Z0-9_\.@]+$/';
 
-    /** @inheritdoc */
-    public function init()
-    {
-        $this->finder = Yii::$container->get(Finder::className());
+    protected function getModule() {
+        return Yii::$app->getModule('user');
+    }
+
+    protected function getFinder() {
+        Yii::$container->get(Finder::className());
+    }
+
+    protected function getMailer() {
         $this->mailer = Yii::$container->get(Mailer::className());
-        $this->module = Yii::$app->getModule('user');
-        parent::init();
     }
 
     /**

--- a/models/User.php
+++ b/models/User.php
@@ -15,6 +15,7 @@ use dektrium\user\Finder;
 use dektrium\user\helpers\Password;
 use dektrium\user\Mailer;
 use dektrium\user\Module;
+use dektrium\user\traits\ModuleTrait;
 use Yii;
 use yii\base\NotSupportedException;
 use yii\behaviors\TimestampBehavior;
@@ -49,11 +50,15 @@ use yii\web\IdentityInterface;
  * @property Profile   $profile
  *
  * Dependencies:
+ * @property-read Finder $finder
+ * @property-read Module $module
+ * @property-read Mailer $mailer
  *
  * @author Dmitry Erofeev <dmeroff@gmail.com>
  */
 class User extends ActiveRecord implements IdentityInterface
 {
+    use ModuleTrait;
     const BEFORE_CREATE   = 'beforeCreate';
     const AFTER_CREATE    = 'afterCreate';
     const BEFORE_REGISTER = 'beforeRegister';
@@ -72,16 +77,20 @@ class User extends ActiveRecord implements IdentityInterface
     /** @var string Default username regexp */
     public static $usernameRegexp = '/^[-a-zA-Z0-9_\.@]+$/';
 
-    protected function getModule() {
-        return Yii::$app->getModule('user');
-    }
-
+    /**
+     * @return Finder
+     * @throws \yii\base\InvalidConfigException
+     */
     protected function getFinder() {
-        Yii::$container->get(Finder::className());
+        return Yii::$container->get(Finder::className());
     }
 
+    /**
+     * @return Mailer
+     * @throws \yii\base\InvalidConfigException
+     */
     protected function getMailer() {
-        $this->mailer = Yii::$container->get(Mailer::className());
+        return Yii::$container->get(Mailer::className());
     }
 
     /**

--- a/tests/codeception/_init.php
+++ b/tests/codeception/_init.php
@@ -1,15 +1,20 @@
 <?php
 
-if (getenv('TEST_ENVIRONMENT') === 'travis') {
-    $vendor = __DIR__.'/../../vendor';
-} else {
-    $vendor = __DIR__.'/../../../../vendor';
+// Search for autoload, since performance is irrelevant and usability isn't!
+$dir = __DIR__;
+while (!file_exists($dir . '/vendor/autoload.php')) {
+    echo "Testing $dir\n";
+    if ($dir == dirname($dir)) {
+        throw new \Exception('Failed to locate autoload.php');
+    }
+    $dir = dirname($dir);
 }
+
+$vendor = $dir . '/vendor';
 
 defined('YII_DEBUG') or define('YII_DEBUG', false);
 defined('YII_ENV') or define('YII_ENV', 'test');
 defined('YII_TEST_ENTRY_URL') or define('YII_TEST_ENTRY_URL', '/index.php');
 defined('YII_TEST_ENTRY_FILE') or define('YII_TEST_ENTRY_FILE', __DIR__.'/_app/web/index.php');
 defined('VENDOR_DIR') or define('VENDOR_DIR', $vendor);
-
 require_once VENDOR_DIR.'/autoload.php';

--- a/traits/ModuleTrait.php
+++ b/traits/ModuleTrait.php
@@ -17,6 +17,6 @@ trait ModuleTrait
      */
     public function getModule()
     {
-        return Yii::$app->getModule('user');
+        return \Yii::$app->getModule('user');
     }
 }

--- a/traits/ModuleTrait.php
+++ b/traits/ModuleTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace dektrium\user\traits;
+
+use dektrium\user\Module;
+
+/**
+ * Trait ModuleTrait
+ * @property-read Module $module
+ * @package dektrium\user\traits
+ */
+trait ModuleTrait
+{
+    /**
+     * @return Module
+     */
+    public function getModule()
+    {
+        return Yii::$app->getModule('user');
+    }
+}


### PR DESCRIPTION
This uses getters for the protected properties in the User model.

This is an improvement to the current implementation, but still it is not an ideal way of dependency injection.