### PR TITLE
Fixed google auth to use first email of emails

### DIFF
--- a/clients/Google.php
+++ b/clients/Google.php
@@ -21,8 +21,8 @@ class Google extends BaseGoogle implements ClientInterface
     /** @inheritdoc */
     public function getEmail()
     {
-        return isset($this->getUserAttributes()['email'])
-            ? $this->getUserAttributes()['email']
+        return isset($this->getUserAttributes()['emails'][0]['value'])
+            ? $this->getUserAttributes()['emails'][0]['value']
             : null;
     }
 


### PR DESCRIPTION
Google returns multiple email adresses in an account. The client only recognizes one. Now updated it to pick the first of the returned emailadresses.