### PR TITLE
fix double-click selection within spaces before

### DIFF
--- a/views/mail/welcome.php
+++ b/views/mail/welcome.php
@@ -26,8 +26,7 @@ use yii\helpers\Html;
 <p style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6; font-weight: normal; margin: 0 0 10px; padding: 0;">
     <?= Yii::t('user', 'Your account on {0} has been created', Yii::$app->name) ?>.
     <?php if ($showPassword || $module->enableGeneratingPassword): ?>
-        <?= Yii::t('user', 'We have generated a password for you') ?>:
-        <strong><?= $user->password ?></strong>
+        <?= Yii::t('user', 'We have generated a password for you') ?>: <strong><?= $user->password ?></strong>
     <?php endif ?>
 
 </p>


### PR DESCRIPTION
Double click on the password in the text of the letter, highlights the extra space.
" h5ErMcP2" -> "h5ErMcP2"