### PR TITLE
i18n ru Поправил перевод

### DIFF
--- a/messages/ru/user.php
+++ b/messages/ru/user.php
@@ -120,7 +120,7 @@ return [
     'Registration ip' => 'Регистрационный IP',
     'Registration time' => 'Время регистрации',
     'Remember me next time' => 'Запомнить меня',
-    'Request new confirmation message' => 'Повторная отправка инструкций',
+    'Request new confirmation message' => 'Активация аккаунта (Повторная отправка письма с активацией)',
     'Reset your password' => 'Сбросить пароль',
     'Roles' => 'Роли',
     'Save' => 'Сохранить',


### PR DESCRIPTION
Фраза "не пришло письмо" мне кажется немного сбивает людей с толку.

Т.к. при попытке войти в неактивированный аккаунт пишет ошибку "Аккаунт не активирован" А под формой кнопки помощи: "не пришло письмо", а если будет написано "активировать аккаунт", то станет понятно что делать дальше.