### PR TITLE
Fixed missing access for confirm email action (if current user was no…

### DIFF
--- a/controllers/SettingsController.php
+++ b/controllers/SettingsController.php
@@ -117,8 +117,13 @@ class SettingsController extends Controller
                 'rules' => [
                     [
                         'allow'   => true,
-                        'actions' => ['profile', 'account', 'confirm', 'networks', 'disconnect'],
+                        'actions' => ['profile', 'account', 'networks', 'disconnect'],
                         'roles'   => ['@'],
+                    ],
+                    [
+                        'allow'   => true,
+                        'actions' => ['confirm'],
+                        'roles'   => ['?', '@'],
                     ],
                 ],
             ],


### PR DESCRIPTION
Small bugfix: if current user is not yet authorized in some situations (for example, session lost), confirm email action (after clicking link with token form mailbox) is not starting and no messages will shown.