### PR TITLE
Admin access via RBAC permission for #385

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -68,6 +68,9 @@ class Module extends BaseModule
 
     /** @var array An array of administrator's usernames. */
     public $admins = [];
+	
+	/** @var string The Administrator permission name. */
+    public $adminPermission;
 
     /** @var array Mailer configuration */
     public $mailer = [];

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,8 +88,18 @@ time user have to request new recovery message.
 #### admins (Type: `array`, Default value: `[]`)
 
 Yii2-user has special admin pages where you can manager registered users or
-create new user accounts. You need to specify username of users that will be
-able to access those pages.
+create new user accounts. You can specify the username of users that will be
+able to access those pages. The most permissive of `admins` and `adminPermission`
+will determine access.
+
+---
+
+#### adminPermission (Type: `string`, Default value: `null`)
+
+Yii2-user has special admin pages where you can manager registered users or
+create new user accounts. You can specify the existing RBAC permission that will
+allow a user to be able to access those pages. The most permissive of `admins`
+and `adminPermission` will determine access.
 
 ---
 

--- a/models/User.php
+++ b/models/User.php
@@ -115,7 +115,7 @@ class User extends ActiveRecord implements IdentityInterface
      */
     public function getIsAdmin()
     {
-        return in_array($this->username, $this->module->admins);
+        return (\Yii::$app->getAuthManager() && $this->module->adminPermission  ? \Yii::$app->user->can($this->module->adminPermission) : false) || in_array($this->username, $this->module->admins);
     }
 
     /**


### PR DESCRIPTION
Pull request for issue #385

Added OR condition to use RBAC permission checking (if configured) to
return true from User::getIsAdmin() if the user has the permission name
defined in Module::$adminPermission.

Updated documentation.