### PR TITLE
fixed empty event on missing profile

### DIFF
--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -253,12 +253,12 @@ class AdminController extends Controller
         Url::remember('', 'actions-redirect');
         $user    = $this->findModel($id);
         $profile = $user->profile;
-        $event   = $this->getProfileEvent($profile);
 
         if ($profile == null) {
             $profile = Yii::createObject(Profile::className());
             $profile->link('user', $user);
         }
+        $event   = $this->getProfileEvent($profile);
 
         $this->performAjaxValidation($profile);
 


### PR DESCRIPTION
I had problems editing user profiles, if the profiles hadn't been created for some reason in the first place.

I looked through the code and while this is also a fix for my problem mentioned above, it looked more nicer to me to use event after the profile check.