### PR TITLE
Token as optional param

### DIFF
--- a/events/ResetPasswordEvent.php
+++ b/events/ResetPasswordEvent.php
@@ -43,7 +43,7 @@ class ResetPasswordEvent extends Event
     /**
      * @param Token $token
      */
-    public function setToken(Token $token)
+    public function setToken(Token $token = null)
     {
         $this->_token = $token;
     }

--- a/traits/EventTrait.php
+++ b/traits/EventTrait.php
@@ -89,7 +89,7 @@ trait EventTrait
      * @return ResetPasswordEvent
      * @throws \yii\base\InvalidConfigException
      */
-    protected function getResetPasswordEvent(Token $token, RecoveryForm $form = null)
+    protected function getResetPasswordEvent(Token $token = null, RecoveryForm $form = null)
     {
         return \Yii::createObject(['class' => ResetPasswordEvent::className(), 'token' => $token, 'form' => $form]);
     }


### PR DESCRIPTION
Because it can be null if there is no record in the database (https://github.com/dektrium/yii2-user/blob/master/controllers/RecoveryController.php#L152)