### PR TITLE
Fallback to safe generated user name

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -417,6 +417,13 @@ class User extends ActiveRecord implements IdentityInterface
             return $this->username;
         }
 
+        // valid email addresses are less restricitve than our
+        // valid username regexp so fallback to 'user123' if needed:
+        if (!preg_match(self::$usernameRegexp, $username)) {
+            $username = 'user';
+        }
+        $this->username = $username;
+
         // generate username like "user1", "user2", etc...
         while (!$this->validate(['username'])) {
             $row = (new Query())


### PR DESCRIPTION
Fallback to safe naming scheme if email name is not a valid user name, fixes issue with PR #698