### PR TITLE
Add css-class "alert-dismissible" to alerts

### DIFF
--- a/views/_alert.php
+++ b/views/_alert.php
@@ -21,7 +21,7 @@ use yii\bootstrap\Alert;
         <div class="col-xs-12">
             <?php foreach (Yii::$app->session->getAllFlashes() as $type => $message): ?>
                 <?php if (in_array($type, ['success', 'danger', 'warning', 'info'])): ?>
-                    <?= Alert::widget(['options' => ['class' => 'alert-'.$type], 'body' => $message]) ?>
+                    <?= Alert::widget(['options' => ['class' => 'alert-dismissible alert-'.$type], 'body' => $message]) ?>
                 <?php endif ?>
             <?php endforeach ?>
         </div>

--- a/views/admin/_assignments.php
+++ b/views/admin/_assignments.php
@@ -22,7 +22,7 @@ use dektrium\rbac\widgets\Assignments;
 
 <?= yii\bootstrap\Alert::widget([
     'options' => [
-        'class' => 'alert-info',
+        'class' => 'alert-info alert-dismissible',
     ],
     'body' => Yii::t('user', 'You can assign multiple roles or permissions to user by using the form below'),
 ]) ?>


### PR DESCRIPTION
Alerts with "close"-Buttons should have the css-class "alert-dismissible"
to align the button properly.
Before patch:
![before-patch](https://cloud.githubusercontent.com/assets/19529106/16157093/6d904cfa-34b7-11e6-9852-f8545cc5fecf.png)
After patch:
![after-patch](https://cloud.githubusercontent.com/assets/19529106/16157098/70bad8aa-34b7-11e6-8b32-2bc42774ea44.png)
