### PR TITLE
Login Security: Avoid brute force attack

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -34,7 +34,7 @@ class Module extends BaseModule
     const STRATEGY_SECURE = 2;
 
     /** @var bool Whether to lock login if there are too many invalid login attempts. */
-    public $enableLockLoginAfterFailedLogin = true;
+    public $enableLockLoginAfterFailedLogin = false;
 
     /** @var int Number of allowed invalid login attempts. */
     public $numberOfAllowedInvalidLoginAttempts = 3;

--- a/Module.php
+++ b/Module.php
@@ -33,6 +33,15 @@ class Module extends BaseModule
     /** Email is changed after user clicks both confirmation links sent to his old and new email addresses. */
     const STRATEGY_SECURE = 2;
 
+    /** @var bool Whether to lock login if there are too many invalid login attempts. */
+    public $enableLockLoginAfterFailedLogin = true;
+
+    /** @var int Number of allowed invalid login attempts. */
+    public $numberOfAllowedInvalidLoginAttempts = 3;
+
+    /** @var int The seconds after the last invalid login attempt when the login attempt counter will be reset. */
+    public $secondsAfterLastInvalidLoginToResetCounter = 3600;
+
     /** @var bool Whether to show flash messages. */
     public $enableFlashMessages = true;
 

--- a/assets/LoginAsset.php
+++ b/assets/LoginAsset.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Dektrium project.
+ *
+ * (c) Dektrium project <http://github.com/dektrium/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace dektrium\user\assets;
+
+use yii\web\AssetBundle;
+
+/**
+ * LoginAsset.
+ */
+class LoginAsset extends AssetBundle
+{
+    /**
+     * @inheritdoc
+     */
+    public $sourcePath = '@dektrium/user/assets';
+    /**
+     * @inheritdoc
+     */
+    public $css = [
+    ];
+    /**
+     * @inheritdoc
+     */
+    public $js = [
+        'login.js',
+    ];
+    /**
+     * @inheritdoc
+     */
+    public $depends = [
+        'yii\web\JqueryAsset',
+    ];
+}

--- a/assets/login.js
+++ b/assets/login.js
@@ -1,0 +1,41 @@
+$(document).ready(function() {
+    var login_form = $("#"+user_login_form);
+    var login_button = login_form.find("button[type=submit]");
+    var button_text_sign_in = login_form.find("button[type=submit]").text();
+    var wait_time = 0;
+    var button_update_text_interval = 0;
+    
+    function set_login_button_text()
+    {
+        if (wait_time > 0) {
+            login_button.text(user_login_button_text_wait.replace("{0}", wait_time--));
+        } else {
+            // stop the interval
+            clearInterval(button_update_text_interval);
+            // restore old sign in text
+            login_button.text(button_text_sign_in);
+            // enable the button:
+            login_button.prop("disabled", false);
+        }
+    }
+
+    $("#login-form").on("ajaxComplete", function (event, jqXHR, textStatus) {
+        // wait_time
+        if (typeof jqXHR["responseJSON"] != "undefined"
+            && typeof jqXHR["responseJSON"]["login-form-password"] != "undefined"
+            && typeof jqXHR["responseJSON"]["login-form-password"][1] != "undefined") {
+            wait_time = jqXHR["responseJSON"]["login-form-password"][1];
+
+            if (wait_time > 0) {
+                // disable the sign in button:
+                login_button.prop("disabled", true);
+                // set wait text
+                set_login_button_text()
+                // update the text every second
+                button_update_text_interval = setInterval(function() { 
+                    set_login_button_text()
+                }, 1000);
+            }
+        }
+    });
+});

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,24 @@ time user have to request new recovery message.
 
 ---
 
+#### enableLockLoginAfterFailedLogin (Type: `boolean`, Default value: `true`)
+
+If this option is true, the login will get locked after too many invalid login attempts.
+
+---
+
+#### numberOfAllowedInvalidLoginAttempts (Type: `integer`, Default value: `3` (3 attempts))
+
+Number of allowed invalid login attempts without locking the login.
+
+---
+
+#### secondsAfterLastInvalidLoginToResetCounter (Type: `integer`, Default value: `3600` (3600 seconds))
+
+This option defines after how many seconds after the last invalid login attempt the attempt counter will be reset.
+
+---
+
 #### admins (Type: `array`, Default value: `[]`)
 
 Yii2-user has special admin pages where you can manager registered users or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,7 @@ time user have to request new recovery message.
 
 ---
 
-#### enableLockLoginAfterFailedLogin (Type: `boolean`, Default value: `true`)
+#### enableLockLoginAfterFailedLogin (Type: `boolean`, Default value: `false`)
 
 If this option is true, the login will get locked after too many invalid login attempts.
 

--- a/messages/de/user.php
+++ b/messages/de/user.php
@@ -18,6 +18,10 @@
  * NOTE: this file must be saved in UTF-8 encoding.
  */
 return [
+    'Attempts' => 'Versuche',
+    'Ip' => 'IP',
+    'Login is locked for {0} seconds.' => 'Login ist für {0} Sekunden gesperrt.',
+    'Please wait' => 'Bitte warten',
     'A confirmation message has been sent to your new email address' => 'Eine Aktivierungsnachricht wurde an ihre E-Mail Adresse versandt',
     'A message has been sent to your email address. It contains a confirmation link that you must click to complete registration.' => 'Eine Nachricht wurde an ihre E-Mail Adresse versandt. Diese enthält einen Aktivierungslink, den Sie besuchen müssen, um die Registrierung fortzusetzen.',
     'A message has been sent to your email address. It contains a password that we generated for you.' => 'Eine Nachricht wurde an ihre E-Mail Adresse versandt. Diese enthält ein Passwort, das für Sie generiert wurde.',

--- a/migrations/m160909_170000_init_login_attempt.php
+++ b/migrations/m160909_170000_init_login_attempt.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Dektrium project.
+ *
+ * (c) Dektrium project <http://github.com/dektrium/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use dektrium\user\migrations\Migration;
+use yii\db\Schema;
+
+/**
+ * @author jkmssoft
+ */
+class m160909_170000_init_login_attempt extends Migration
+{
+    public function up()
+    {
+        $this->createTable('{{%login_attempt}}', [
+            'id'                => Schema::TYPE_PK,
+            'ip'                => Schema::TYPE_STRING . '(32)', // store only md5-sum!
+            'attempts'          => Schema::TYPE_INTEGER . ' NULL',
+            'last_attempt_at'   => Schema::TYPE_INTEGER . ' NULL',
+        ], $this->tableOptions);
+
+        $this->createIndex('login_attempt_unique_ip', '{{%login_attempt}}', 'ip', true);
+    }
+
+    public function down()
+    {
+        $this->dropIndex('login_attempt_unique_ip', '{{%login_attempt}}');
+        $this->dropTable('{{%login_attempt}}');
+    }
+}

--- a/models/LoginAttempt.php
+++ b/models/LoginAttempt.php
@@ -95,14 +95,4 @@ class LoginAttempt extends \yii\db\ActiveRecord
         $seconds = time() - \Yii::$app->getModule('user')->secondsAfterLastInvalidLoginToResetCounter;
         return self::deleteAll(['<=', 'last_attempt_at', $seconds]) !== false;
     }
-    
-    /**
-     * Remove invalid login attempt by ip.
-     * @param string $ip
-     * @return boolean Delete result: true on success else false.
-     */
-    public static function removeByIp($ip)
-    {
-        return self::deleteAll(['=', 'ip', $ip]) !== false;
-    }
 }

--- a/models/LoginAttempt.php
+++ b/models/LoginAttempt.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Dektrium project.
+ *
+ * (c) Dektrium project <http://github.com/dektrium/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace dektrium\user\models;
+
+/**
+ * This is the model class for table "{{%login_attempt}}".
+ *
+ * @property integer $id
+ * @property string $ip                 md5-sum of the ip
+ * @property integer $attempts          Counter
+ * @property integer $last_attempt_at   Unix timestamp (epoch time)
+ *
+ * @author jkmssoft
+ */
+class LoginAttempt extends \yii\db\ActiveRecord
+{
+    use \dektrium\user\traits\ModuleTrait;
+
+    /**
+     * @inheritdoc
+     */
+    public static function tableName()
+    {
+        return '{{%login_attempt}}';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function rules()
+    {
+        return [
+            [['attempts', 'last_attempt_at'], 'integer'],
+            [['ip'], 'string', 'max' => 32],
+            [['ip'], 'unique'],
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function attributeLabels()
+    {
+        return [
+            'id' => \Yii::t('user', 'ID'),
+            'ip' => \Yii::t('user', 'Ip'),
+            'attempts' => \Yii::t('user', 'Attempts'),
+            'last_attempt_at' => \Yii::t('user', 'Last Attempt At'),
+        ];
+    }
+
+    /**
+     * Get the remaining seconds for the login lock.
+     * @return integer seconds
+     */
+    public function getLoginLockTime()
+    {
+        $lockTime = 0;
+        if ($this->attempts > $this->module->numberOfAllowedInvalidLoginAttempts) {
+            $lockTime = pow($this->attempts - $this->module->numberOfAllowedInvalidLoginAttempts, 2);
+            $time = time();
+            if ($time - $this->last_attempt_at <= $lockTime) {
+                $lockTime = $lockTime - ($time - $this->last_attempt_at);
+            } else {
+                $lockTime = 0;
+            }
+        }
+        return $lockTime;
+    }
+
+    /**
+     * @inheritdoc
+     * @return \dektrium\user\models\query\LoginAttemptQuery the active query used by this AR class.
+     */
+    public static function find()
+    {
+        return new \dektrium\user\models\query\LoginAttemptQuery(get_called_class());
+    }
+    
+    /**
+     * Delete old data.
+     * @return boolean Delete result: true on success else false.
+     */
+    public static function purgeOld()
+    {
+        $seconds = time() - \Yii::$app->getModule('user')->secondsAfterLastInvalidLoginToResetCounter;
+        return self::deleteAll(['<=', 'last_attempt_at', $seconds]) !== false;
+    }
+    
+    /**
+     * Remove invalid login attempt by ip.
+     * @param string $ip
+     * @return boolean Delete result: true on success else false.
+     */
+    public static function removeByIp($ip)
+    {
+        return self::deleteAll(['=', 'ip', $ip]) !== false;
+    }
+}

--- a/models/LoginForm.php
+++ b/models/LoginForm.php
@@ -180,7 +180,6 @@ class LoginForm extends Model
     public function login()
     {
         if ($this->validate()) {
-            LoginAttempt::removeByIp(md5(Yii::$app->request->getUserIp()));
             return Yii::$app->getUser()->login($this->user, $this->rememberMe ? $this->module->rememberFor : 0);
         } else {
             return false;

--- a/models/query/LoginAttemptQuery.php
+++ b/models/query/LoginAttemptQuery.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Dektrium project.
+ *
+ * (c) Dektrium project <http://github.com/dektrium/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace dektrium\user\models\query;
+
+/**
+ * This is the ActiveQuery class for [[LoginAttempt]].
+ *
+ * @see LoginAttempt
+ * @author jkmssoft
+ */
+class LoginAttemptQuery extends \yii\db\ActiveQuery
+{
+    /**
+     * @inheritdoc
+     * @return LoginAttempt[]|array
+     */
+    public function all($db = null)
+    {
+        return parent::all($db);
+    }
+
+    /**
+     * @inheritdoc
+     * @return LoginAttempt|array|null
+     */
+    public function one($db = null)
+    {
+        return parent::one($db);
+    }
+}

--- a/tests/_fixtures/LoginAttemptFixture.php
+++ b/tests/_fixtures/LoginAttemptFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace tests\_fixtures;
+
+use yii\test\ActiveFixture;
+
+class LoginAttemptFixture extends ActiveFixture
+{
+    public $modelClass = 'dektrium\user\models\LoginAttempt';
+}

--- a/tests/_fixtures/data/login_attempt.php
+++ b/tests/_fixtures/data/login_attempt.php
@@ -1,0 +1,16 @@
+<?php
+
+$time = time();
+
+return [
+    'test' => [
+        'ip'                => '837ec5754f503cfaaee0929fd48974e7',
+        'attempts'          => 10,
+        'last_attempt_at'   => $time,
+    ],
+    'lockTime0' => [
+        'ip'                => '837ec5754f503cfaaee0929fd48974e8',
+        'attempts'          => 1,
+        'last_attempt_at'   => $time,
+    ],
+];

--- a/tests/functional/LoginAttemptCest.php
+++ b/tests/functional/LoginAttemptCest.php
@@ -1,0 +1,80 @@
+<?php
+
+use tests\_fixtures\UserFixture;
+use tests\_pages\LoginPage;
+use dektrium\user\Module;
+
+class LoginAttemptCest
+{
+    public function _before(FunctionalTester $I)
+    {
+        $I->haveFixtures(['user' => UserFixture::className()]);
+    }
+
+    public function _after(FunctionalTester $I)
+    {
+        \Yii::$container->set(Module::className(), [
+            'enableLockLoginAfterFailedLogin' => false,
+            'numberOfAllowedInvalidLoginAttempts' => 3,
+            'secondsAfterLastInvalidLoginToResetCounter' => 3600,
+        ]);
+    }
+
+    /**
+     * Test log in with invalid credentials.
+     * @param FunctionalTester $I
+     */
+    public function testLoginSecurity(FunctionalTester $I)
+    {
+        \Yii::$container->set(Module::className(), [
+            'enableLockLoginAfterFailedLogin' => true,
+            'numberOfAllowedInvalidLoginAttempts' => 3,
+            'secondsAfterLastInvalidLoginToResetCounter' => 3600,
+        ]);
+
+        $page = LoginPage::openBy($I);
+
+        $I->wantTo('ensure that login security works');
+
+        $user = $I->grabFixture('user', 'user');
+
+        $I->amGoingTo('1. attempt: try to login with wrong credentials');
+        $page->login($user->email, 'wrong');
+        $I->expectTo('see validations errors');
+        $I->see('Invalid login or password');
+
+        $I->amGoingTo('2. attempt: try to login with wrong credentials');
+        $page->login($user->email, 'wrong');
+        $I->expectTo('see validations errors');
+        $I->see('Invalid login or password');
+
+        $I->amGoingTo('3. attempt: try to login with wrong credentials');
+        $page->login($user->email, 'wrong');
+        $I->expectTo('see validations errors');
+        $I->see('Invalid login or password');
+
+        $I->amGoingTo('4. attempt: try to login with wrong credentials');
+        $page->login($user->email, 'wrong');
+        $I->expectTo('see login attempt error');
+        $I->see('Login is locked for 1 seconds');
+       
+        sleep(2);
+        
+        $I->amGoingTo('5. attempt: try to login with wrong credentials');
+        $page->login($user->email, 'wrong');
+        $I->expectTo('see login attempt error');
+        $I->see('Invalid login or password. Login is locked for 4 seconds.');
+
+        $I->amGoingTo('6. attempt: try to login with wrong credentials');
+        $page->login($user->email, 'wrong');
+        $I->expectTo('see login attempt error');
+        $I->see('Invalid login or password. Login is locked for');
+        
+        sleep(5);
+        
+        $I->amGoingTo('try to login with correct credentials');
+        $page->login($user->email, 'qwerty');
+        $I->dontSee('Login');
+        $I->see('Logout');
+    }
+}

--- a/tests/unit/models/LoginAttemptTest.php
+++ b/tests/unit/models/LoginAttemptTest.php
@@ -47,16 +47,4 @@ class LoginAttemptTest extends \Codeception\Test\Unit
     {
         $this->assertTrue(LoginAttempt::purgeOld() >= 0);
     }
-    
-    /**
-     * Test removeByIp method.
-     */
-    public function testRemoveByIp()
-    {
-        $this->tester->haveFixtures(['login_attempt' => LoginAttemptFixture::className()]);
-        $fixture = $this->tester->grabFixture('login_attempt', 'test');
-        $item = $this->tester->grabRecord(LoginAttempt::className(), ['ip' => $fixture->ip]);
-        $this->assertTrue(LoginAttempt::removeByIp($fixture->ip) >= 0);
-        $this->tester->dontSeeRecord(LoginAttempt::className(), ['ip' => $fixture->ip]);
-    }
 }

--- a/tests/unit/models/LoginAttemptTest.php
+++ b/tests/unit/models/LoginAttemptTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace tests\unit\models;
+
+use dektrium\user\models\LoginAttempt;
+use Codeception\Specify;
+use tests\_fixtures\LoginAttemptFixture;
+
+/**
+ * Test the login attempt model.
+ */
+class LoginAttemptTest extends \Codeception\Test\Unit
+{
+    use Specify;
+    
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+    
+    /**
+     * Test getLoginLockTime method.
+     */
+    public function testGetLoginLockTime()
+    {
+        $this->specify('lockTime > 0', function () {
+            $this->tester->haveFixtures(['login_attempt' => LoginAttemptFixture::className()]);
+            $fixture = $this->tester->grabFixture('login_attempt', 'test');
+            $model = LoginAttempt::find()->where(['ip' => $fixture->ip])->one();
+            $this->assertTrue($model->attempts == $fixture->attempts);
+            $this->assertTrue($model->getLoginLockTime() > 0);
+        });
+        
+        $this->specify('lockTime is 0', function () {
+            $this->tester->haveFixtures(['login_attempt' => LoginAttemptFixture::className()]);
+            $fixture = $this->tester->grabFixture('login_attempt', 'lockTime0');
+            $model = LoginAttempt::find()->where(['ip' => $fixture->ip])->one();
+            $this->assertTrue($model->attempts == $fixture->attempts);
+            $this->assertTrue($model->getLoginLockTime() == 0);
+        });
+    }
+
+    /**
+     * Test purgeOld method.
+     */
+    public function testPurgeOld()
+    {
+        $this->assertTrue(LoginAttempt::purgeOld() >= 0);
+    }
+    
+    /**
+     * Test removeByIp method.
+     */
+    public function testRemoveByIp()
+    {
+        $this->tester->haveFixtures(['login_attempt' => LoginAttemptFixture::className()]);
+        $fixture = $this->tester->grabFixture('login_attempt', 'test');
+        $item = $this->tester->grabRecord(LoginAttempt::className(), ['ip' => $fixture->ip]);
+        $this->assertTrue(LoginAttempt::removeByIp($fixture->ip) >= 0);
+        $this->tester->dontSeeRecord(LoginAttempt::className(), ['ip' => $fixture->ip]);
+    }
+}

--- a/views/security/login.php
+++ b/views/security/login.php
@@ -10,6 +10,7 @@
  */
 
 use dektrium\user\widgets\Connect;
+use dektrium\user\assets\LoginAsset;
 use yii\helpers\Html;
 use yii\widgets\ActiveForm;
 
@@ -21,6 +22,7 @@ use yii\widgets\ActiveForm;
 
 $this->title = Yii::t('user', 'Sign in');
 $this->params['breadcrumbs'][] = $this->title;
+
 ?>
 
 <?= $this->render('/_alert', ['module' => Yii::$app->getModule('user')]) ?>
@@ -39,7 +41,16 @@ $this->params['breadcrumbs'][] = $this->title;
                     'validateOnBlur'         => false,
                     'validateOnType'         => false,
                     'validateOnChange'       => false,
-                ]) ?>
+                ]);
+                
+                if ($module->enableLockLoginAfterFailedLogin) {
+                    LoginAsset::register($this);
+
+                    $this->registerJs('
+                    var user_login_form = "'.$form->id.'";
+                    var user_login_button_text_wait = "'.Yii::t('user', 'Login is locked for {0} seconds.').'";
+                    ', \yii\web\View::POS_END, 'user-login-form-options');
+                } ?>
 
                 <?= $form->field(
                     $model,

--- a/views/security/login.php
+++ b/views/security/login.php
@@ -48,7 +48,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
                     $this->registerJs('
                     var user_login_form = "'.$form->id.'";
-                    var user_login_button_text_wait = "'.Yii::t('user', 'Login is locked for {0} seconds.').'";
+                    var user_login_button_text_wait = "'.Yii::t('user', 'Please wait').': '.Yii::t('user', 'Login is locked for {0} seconds.').'";
                     ', \yii\web\View::POS_END, 'user-login-form-options');
                 } ?>
 


### PR DESCRIPTION
Add new database table "login_attempt" where invalid login attempts
are logged.
After 3 invalid login attempts the login will get locked for only
a few seconds.
The lock time will increase for each new invalid login attempt.
New configuration attributes added:
- enableLockLoginAfterFailedLogin
- numberOfAllowedInvalidLoginAttempts
- secondsAfterLastInvalidLoginToResetCounter

![loginsecurity](https://cloud.githubusercontent.com/assets/19529106/19195179/be195152-8cb0-11e6-84d3-f7f96d01947d.png)

TODO:
Maybe somebody adds some Acceptance Tests?

| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Fixed issues |  |
