### PR TITLE
Add ability to switch back to previous user when impersonated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Enh #795: Added method `getAccountByProvider` to User model to get account model by provider name (dmeroff)
 - Fix #778: Migrations now use correct db component (dmeroff)
 - Fix #777: Rethrow exception on failed user creation or registration (dmeroff)
-- Enh #772, #791: Added ability to log into another user's account (thyseus)
+- Enh #772, #791: Added ability to log into another user's account and back to previous user (thyseus)
 - Fix #761: Fixed EVENT_AFTER_CONFIRM not triggering on user creation (dmeroff)
 - Fix #757: Fixed tabindex order in security/login.php view (dmeroff)
 

--- a/Module.php
+++ b/Module.php
@@ -54,6 +54,9 @@ class Module extends BaseModule
     /** @var bool Whether user can remove his account */
     public $enableAccountDelete = false;
 
+    /** @var bool Enable the 'impersonate as another user' function */
+    public $enableImpersonateUser = true;
+
     /** @var int Email changing strategy. */
     public $emailChangeStrategy = self::STRATEGY_DEFAULT;
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The latest version includes following features:
 * Account and profile management
 * Console commands
 * User management interface
+* Ability to impersonate as another user given admin access is available
 
 > **NOTE:** Module is in initial development. Anything may change at any time.
 

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -309,16 +309,18 @@ class AdminController extends Controller
 
     /**
      * Switches to the given user for the rest of the Session.
+     * When no id is given, we switch back to the original admin user
+     * that started the impersonation.
      *
      * @param int $id
      *
      * @return string
      */
-    public function actionSwitch($id)
+    public function actionSwitch($id = null)
     {
         $key = self::ORIGINAL_USER_SESSION_KEY;
 
-        if($id == 'original' && Yii::$app->session->has($key)) {
+        if(!$id && Yii::$app->session->has($key)) {
             $user = $this->findModel(Yii::$app->session->get($key));
             Yii::$app->session->remove($key);
         } else {

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -126,6 +126,13 @@ class AdminController extends Controller
      */
     const EVENT_AFTER_UNBLOCK = 'afterUnblock';
 
+    /**
+     * Name of the session key in which the original user id is saved
+     * when using the impersonate user function.
+     * Used inside actionSwitch().
+     */
+    const ORIGINAL_USER_SESSION_KEY = 'original_user';
+
     /** @var Finder */
     protected $finder;
 
@@ -310,16 +317,17 @@ class AdminController extends Controller
     {
         $old = Yii::$app->user;
         $session = Yii::$app->session;
+        $key = self::ORIGINAL_USER_SESSION_KEY;
 
-        if($id == 'original' && $session->has('original_user')) {
-            $user = $this->findModel($session->get('original_user'));
-            $session->remove('original_user');
+        if($id == 'original' && $session->has($key)) {
+            $user = $this->findModel($session->get($key));
+            $session->remove($key);
         } else {
             if (!Yii::$app->user->can('admin'))
                 throw new ForbiddenHttpException;
 
             $user = $this->findModel($id);
-            Yii::$app->session->set('original_user', $old->id);
+            Yii::$app->session->set($key, $old->id);
         }
 
         Yii::$app->user->switchIdentity($user, 3600);

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -318,6 +318,9 @@ class AdminController extends Controller
      */
     public function actionSwitch($id = null)
     {
+        if(!Yii::$app->getModule('user')->enableImpersonateUser)
+            throw new ForbiddenHttpException(Yii::t('user', 'Impersonate user is disabled in the application configuration'));
+
         $key = self::ORIGINAL_USER_SESSION_KEY;
 
         if(!$id && Yii::$app->session->has($key)) {

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -318,29 +318,21 @@ class AdminController extends Controller
      */
     public function actionSwitch($id = null)
     {
-        if(!Yii::$app->getModule('user')->enableImpersonateUser)
+        if (!Yii::$app->getModule('user')->enableImpersonateUser)
             throw new ForbiddenHttpException(Yii::t('user', 'Impersonate user is disabled in the application configuration'));
 
-        $key = self::ORIGINAL_USER_SESSION_KEY;
-
-        if(!$id && Yii::$app->session->has($key)) {
-            $user = $this->findModel(Yii::$app->session->get($key));
-            Yii::$app->session->remove($key);
+        if(!$id && Yii::$app->session->has(self::ORIGINAL_USER_SESSION_KEY)) {
+            $user = $this->findModel(Yii::$app->session->get(self::ORIGINAL_USER_SESSION_KEY));
+            Yii::$app->session->remove(self::ORIGINAL_USER_SESSION_KEY);
         } else {
             if (!Yii::$app->user->identity->isAdmin)
                 throw new ForbiddenHttpException;
 
             $user = $this->findModel($id);
-            Yii::$app->session->set($key, Yii::$app->user->id);
+            Yii::$app->session->set(self::ORIGINAL_USER_SESSION_KEY, Yii::$app->user->id);
         }
 
         Yii::$app->user->switchIdentity($user, 3600);
-
-        Yii::warning(sprintf('User %s(id: %d) switched to user %s(id: %d).',
-            Yii::$app->user->identity->username,
-            Yii::$app->user->id,
-            Yii::$app->user->identity->username,
-            Yii::$app->user->id));
 
         return $this->goHome();
     }

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -336,8 +336,8 @@ class AdminController extends Controller
         Yii::warning(sprintf('User %s(id: %d) switched to user %s(id: %d).',
             Yii::$app->user->identity->username,
             Yii::$app->user->id,
-            \Yii::$app->user->identity->username,
-            \Yii::$app->user->id));
+            Yii::$app->user->identity->username,
+            Yii::$app->user->id));
 
         return $this->goHome();
     }

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -316,25 +316,26 @@ class AdminController extends Controller
      */
     public function actionSwitch($id)
     {
-        $old = Yii::$app->user;
-        $session = Yii::$app->session;
         $key = self::ORIGINAL_USER_SESSION_KEY;
 
-        if($id == 'original' && $session->has($key)) {
-            $user = $this->findModel($session->get($key));
-            $session->remove($key);
+        if($id == 'original' && Yii::$app->session->has($key)) {
+            $user = $this->findModel(Yii::$app->session->get($key));
+            Yii::$app->session->remove($key);
         } else {
             if (!Yii::$app->user->can('admin'))
                 throw new ForbiddenHttpException;
 
             $user = $this->findModel($id);
-            Yii::$app->session->set($key, $old->id);
+            Yii::$app->session->set($key, Yii::$app->user->id);
         }
 
         Yii::$app->user->switchIdentity($user, 3600);
 
         Yii::warning(sprintf('User %s(id: %d) switched to user %s(id: %d).',
-            $old->identity->username, $old->id, \Yii::$app->user->identity->username, \Yii::$app->user->id));
+            Yii::$app->user->identity->username,
+            Yii::$app->user->id,
+            \Yii::$app->user->identity->username,
+            \Yii::$app->user->id));
 
         return $this->goHome();
     }

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -322,7 +322,7 @@ class AdminController extends Controller
             $user = $this->findModel(Yii::$app->session->get($key));
             Yii::$app->session->remove($key);
         } else {
-            if (!Yii::$app->user->can('admin'))
+            if (!Yii::$app->user->identity->isAdmin)
                 throw new ForbiddenHttpException;
 
             $user = $this->findModel($id);

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -18,6 +18,7 @@ use dektrium\user\models\User;
 use dektrium\user\models\UserSearch;
 use dektrium\user\Module;
 use dektrium\user\traits\EventTrait;
+use yii;
 use yii\base\ExitException;
 use yii\base\Model;
 use yii\base\Module as Module2;
@@ -28,6 +29,7 @@ use yii\web\Controller;
 use yii\web\NotFoundHttpException;
 use yii\web\Response;
 use yii\widgets\ActiveForm;
+
 
 /**
  * AdminController allows you to administrate users.
@@ -301,13 +303,19 @@ class AdminController extends Controller
      */
     public function actionSwitch($id)
     {
-        $user = $this->findModel($id);
+        if($id == 'previous') {
+            $previous = Yii::$app->session->get('previous_user');
+            $user = $this->findModel($previous);
+        } else
+            $user = $this->findModel($id);
 
-        $old = \Yii::$app->user;
+        $old = Yii::$app->user;
 
-        \Yii::$app->user->switchIdentity($user, 3600);
+        Yii::$app->session->set('previous_user', $old->id);
 
-        \Yii::warning(sprintf('User %s(id: %d) switched to user %s(id: %d).',
+        Yii::$app->user->switchIdentity($user, 3600);
+
+        Yii::warning(sprintf('User %s(id: %d) switched to user %s(id: %d).',
                 $old->identity->username, $old->id, \Yii::$app->user->identity->username, \Yii::$app->user->id));
 
         return $this->goBack();

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -158,6 +158,7 @@ class AdminController extends Controller
                     'delete'  => ['post'],
                     'confirm' => ['post'],
                     'block'   => ['post'],
+                    'switch'  => ['post'],
                 ],
             ],
             'access' => [

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -330,16 +330,18 @@ class AdminController extends Controller
      */
     public function actionSwitch($id = null)
     {
-        if (!Yii::$app->getModule('user')->enableImpersonateUser)
+        if (!$this->module->enableImpersonateUser) {
             throw new ForbiddenHttpException(Yii::t('user', 'Impersonate user is disabled in the application configuration'));
+        }
 
         if(!$id && Yii::$app->session->has(self::ORIGINAL_USER_SESSION_KEY)) {
             $user = $this->findModel(Yii::$app->session->get(self::ORIGINAL_USER_SESSION_KEY));
 
             Yii::$app->session->remove(self::ORIGINAL_USER_SESSION_KEY);
         } else {
-            if (!Yii::$app->user->identity->isAdmin)
+            if (!Yii::$app->user->identity->isAdmin) {
                 throw new ForbiddenHttpException;
+            }
 
             $user = $this->findModel($id);
             Yii::$app->session->set(self::ORIGINAL_USER_SESSION_KEY, Yii::$app->user->id);

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -311,15 +311,15 @@ class AdminController extends Controller
         $old = Yii::$app->user;
         $session = Yii::$app->session;
 
-        if($id == 'previous' && $session->has('previous_user')) {
-            $user = $this->findModel($session->get('previous_user'));
-            $session->remove('previous_user');
+        if($id == 'original' && $session->has('original_user')) {
+            $user = $this->findModel($session->get('original_user'));
+            $session->remove('original_user');
         } else {
             if (!Yii::$app->user->can('admin'))
                 throw new ForbiddenHttpException;
 
             $user = $this->findModel($id);
-            Yii::$app->session->set('previous_user', $old->id);
+            Yii::$app->session->set('original_user', $old->id);
         }
 
         Yii::$app->user->switchIdentity($user, 3600);

--- a/docs/user-management.md
+++ b/docs/user-management.md
@@ -41,6 +41,25 @@ id query parameter.
 Route **/user/admin/delete** deletes an user account. To access this route you should specify id query parameter and do
 a POST request. Be careful, you will not be able to restore deleted account.
 
+### Impersonate User / Become another user
+
+Route **/user/admin/switch** becomes an user for the current session. You need to be an administrator to use this
+feature. Place something like this in your view file to allow to jump back when being impersonated as another person:
+
+```
+if(Yii::$app->session->has('previous_user'))
+    echo Html::a('<span class="glyphicon glyphicon-user"></span>Previous User', ['//user/admin/switch', 'id' = 'previous'], ['class' => 'btn btn-primary']);
+```
+
+or
+
+```
+echo Nav::widget([
+    'items' => [
+        ['label' => '<span class="glyphicon glyphicon-user"></span>Previous user', 'visible' => Yii::$app->session->has('previous_user'), 'url' => ['//user/admin/switch', 'id' => 'previous']],
+      ],
+```
+
 ##Changing CRUD layout
 
 Sometimes you will need to have different layouts for frontend and backend pages. It is really easy to change admin layout:

--- a/docs/user-management.md
+++ b/docs/user-management.md
@@ -47,10 +47,11 @@ Route **/user/admin/switch** becomes an user for the current session. You need t
 feature. Place something like this in your view file to allow to jump back when being impersonated as another person:
 
 ```
-if(Yii::$app->session->has('previous_user'))
+$key = \dektrium\user\controllers\AdminController::ORIGINAL_USER_SESSION_KEY;
+if(Yii::$app->session->has($key))
     echo Html::a(
-    '<span class="glyphicon glyphicon-user"></span>Previous User',
-     ['//user/admin/switch', 'id' = 'previous'], ['class' => 'btn btn-primary', 'data-method' => 'POST']);
+    '<span class="glyphicon glyphicon-user"></span> Back to original user',
+     ['//user/admin/switch', 'id' = 'original'], ['class' => 'btn btn-primary', 'data-method' => 'POST']);
 ```
 
 or

--- a/docs/user-management.md
+++ b/docs/user-management.md
@@ -48,15 +48,22 @@ feature. Place something like this in your view file to allow to jump back when 
 
 ```
 if(Yii::$app->session->has('previous_user'))
-    echo Html::a('<span class="glyphicon glyphicon-user"></span>Previous User', ['//user/admin/switch', 'id' = 'previous'], ['class' => 'btn btn-primary']);
+    echo Html::a(
+    '<span class="glyphicon glyphicon-user"></span>Previous User',
+     ['//user/admin/switch', 'id' = 'previous'], ['class' => 'btn btn-primary', 'data-method' => 'POST']);
 ```
 
 or
 
 ```
+$key = \dektrium\user\controllers\AdminController::ORIGINAL_USER_SESSION_KEY;
 echo Nav::widget([
     'items' => [
-        ['label' => '<span class="glyphicon glyphicon-user"></span>Previous user', 'visible' => Yii::$app->session->has('previous_user'), 'url' => ['//user/admin/switch', 'id' => 'previous']],
+        Yii::$app->session->has($key) ?
+        Html::beginForm(['/user/admin/switch', 'id' => 'original' ], 'post', ['class' => 'navbar-form'])
+            . Html::submitButton('<span class="glyphicon glyphicon-user"></span> Back to original user',
+                ['class' => 'btn btn-link']
+            ) . Html::endForm() : '',
       ],
 ```
 

--- a/docs/user-management.md
+++ b/docs/user-management.md
@@ -51,7 +51,7 @@ $key = \dektrium\user\controllers\AdminController::ORIGINAL_USER_SESSION_KEY;
 if(Yii::$app->session->has($key))
     echo Html::a(
     '<span class="glyphicon glyphicon-user"></span> Back to original user',
-     ['//user/admin/switch', 'id' = 'original'], ['class' => 'btn btn-primary', 'data-method' => 'POST']);
+     ['//user/admin/switch'], ['class' => 'btn btn-primary', 'data-method' => 'POST']);
 ```
 
 or
@@ -61,7 +61,7 @@ $key = \dektrium\user\controllers\AdminController::ORIGINAL_USER_SESSION_KEY;
 echo Nav::widget([
     'items' => [
         Yii::$app->session->has($key) ?
-        Html::beginForm(['/user/admin/switch', 'id' => 'original' ], 'post', ['class' => 'navbar-form'])
+        Html::beginForm(['/user/admin/switch'], 'post', ['class' => 'navbar-form'])
             . Html::submitButton('<span class="glyphicon glyphicon-user"></span> Back to original user',
                 ['class' => 'btn btn-link']
             ) . Html::endForm() : '',

--- a/docs/user-management.md
+++ b/docs/user-management.md
@@ -61,10 +61,10 @@ $key = \dektrium\user\controllers\AdminController::ORIGINAL_USER_SESSION_KEY;
 echo Nav::widget([
     'items' => [
         Yii::$app->session->has($key) ?
-        Html::beginForm(['/user/admin/switch'], 'post', ['class' => 'navbar-form'])
+        '<li>' . Html::beginForm(['/user/admin/switch'], 'post', ['class' => 'navbar-form'])
             . Html::submitButton('<span class="glyphicon glyphicon-user"></span> Back to original user',
                 ['class' => 'btn btn-link']
-            ) . Html::endForm() : '',
+            ) . Html::endForm() . '</li>' : '',
       ],
 ```
 

--- a/docs/user-management.md
+++ b/docs/user-management.md
@@ -47,8 +47,7 @@ Route **/user/admin/switch** becomes an user for the current session. You need t
 feature. Place something like this in your view file to allow to jump back when being impersonated as another person:
 
 ```
-$key = \dektrium\user\controllers\AdminController::ORIGINAL_USER_SESSION_KEY;
-if(Yii::$app->session->has($key))
+if (Yii::$app->session->has(\dektrium\user\controllers\AdminController::ORIGINAL_USER_SESSION_KEY))
     echo Html::a(
     '<span class="glyphicon glyphicon-user"></span> Back to original user',
      ['//user/admin/switch'], ['class' => 'btn btn-primary', 'data-method' => 'POST']);
@@ -57,10 +56,9 @@ if(Yii::$app->session->has($key))
 or
 
 ```
-$key = \dektrium\user\controllers\AdminController::ORIGINAL_USER_SESSION_KEY;
 echo Nav::widget([
     'items' => [
-        Yii::$app->session->has($key) ?
+        Yii::$app->session->has(\dektrium\user\controllers\AdminController::ORIGINAL_USER_SESSION_KEY;) ?
         '<li>' . Html::beginForm(['/user/admin/switch'], 'post', ['class' => 'navbar-form'])
             . Html::submitButton('<span class="glyphicon glyphicon-user"></span> Back to original user',
                 ['class' => 'btn btn-link']

--- a/docs/user-management.md
+++ b/docs/user-management.md
@@ -50,7 +50,7 @@ feature. Place something like this in your view file to allow to jump back when 
 if (Yii::$app->session->has(\dektrium\user\controllers\AdminController::ORIGINAL_USER_SESSION_KEY))
     echo Html::a(
     '<span class="glyphicon glyphicon-user"></span> Back to original user',
-     ['//user/admin/switch'], ['class' => 'btn btn-primary', 'data-method' => 'POST']);
+     ['/user/admin/switch'], ['class' => 'btn btn-primary', 'data-method' => 'POST']);
 ```
 
 or

--- a/messages/de/user.php
+++ b/messages/de/user.php
@@ -170,6 +170,7 @@ return [
     'In order to complete your registration, please click the link below' => 'Um die Registrierung abzuschließen, klicken Sie bitte auf den folgenden Link',
     'In order to complete your request, please click the link below' => 'Um die Anfrage abzuschließen, klicken Sie bitte auf den folgenden Link',
     'Information' => 'Information',
+    'Impersonate user is disabled in the application configuration' => 'Das wechseln zu anderen Nutzern wurde deaktiviert',
     'Invalid login or password' => 'Benutzername oder Passwort ungültig',
     'Joined on {0, date}' => 'Registriert am d. {0, date}',
     'Location' => 'Standort',

--- a/messages/de/user.php
+++ b/messages/de/user.php
@@ -206,7 +206,7 @@ return [
     'User has been unblocked' => 'Benutzer ist nicht länger blockiert',
     'Username' => 'Benutzername',
     'Users' => 'Benutzer',
-    'We have generated a password for you' => 'Wir haben ein Passwort für Sie erstellt'
+    'We have generated a password for you' => 'Wir haben ein Passwort für Sie erstellt',
     'We have received a request to change the email address for your account on {0}' => 'Wir haben eine Anfrage erhalten, die E-Mail-Adresse für Ihr Konto auf {0} zu ändern',
     'We have received a request to reset the password for your account on {0}' => 'Wir haben eine Anfrage erhalten, Ihr Passwort auf {0} zurückzusetzen',
     'Website' => 'Webseite',

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -106,6 +106,7 @@ $this->params['breadcrumbs'][] = $this->title;
                         return Html::a('<span class="glyphicon glyphicon-user"></span>', ['/user/admin/switch', 'id' => $model->id], [
                             'title' => Yii::t('user', 'Become this user'),
                             'data-confirm' => Yii::t('user', 'Are you sure you want to switch to this user for the rest of this Session?'),
+                            'data-method' => 'POST',
                         ]);
                 }
             ],

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -102,7 +102,7 @@ $this->params['breadcrumbs'][] = $this->title;
             'template' => '{switch} {update} {delete}',
             'buttons' => [
                 'switch' => function ($url, $model) {
-                    if($model->id != Yii::$app->user->id)
+                    if($model->id != Yii::$app->user->id && Yii::$app->getModule('user')->enableImpersonateUser)
                         return Html::a('<span class="glyphicon glyphicon-user"></span>', ['/user/admin/switch', 'id' => $model->id], [
                             'title' => Yii::t('user', 'Become this user'),
                             'data-confirm' => Yii::t('user', 'Are you sure you want to switch to this user for the rest of this Session?'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no


Please check if there are any security concerns using this approach. Could the session param 'previous_user' be modified by an intruder somehow? Thanks.