### PR TITLE
Fix table_prefix on add_last_login migration

### DIFF
--- a/migrations/m170106_160013_add_approved_at_column_to_user.php
+++ b/migrations/m170106_160013_add_approved_at_column_to_user.php
@@ -2,15 +2,16 @@
 
 use yii\db\Migration;
 
-class m170106_160013_add_approved_at_column_to_user extends Migration
+class m160929_103127_add_last_login_at_to_user_table extends Migration
 {
-    public function safeUp()
-    {
-        $this->addColumn('user', 'approved_at', $this->integer());
-    }
+  public function up()
+  {
+    $this->addColumn('{{%user}}', 'last_login_at', $this->integer());
 
-    public function safeDown()
-    {
-        $this->dropColumn('user', 'approved_at');
-    }
+  }
+
+  public function down()
+  {
+    $this->dropColumn('{{%user}}', 'last_login_at');
+  }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Fixed issues  | 

Hi Dektrium, 

this pull request fix a problem with table_prefix missing on migration m170106_160013_add_approved_at_column_to_user.php