### PR TITLE
Fix init migration

### DIFF
--- a/migrations/m140209_132017_init.php
+++ b/migrations/m140209_132017_init.php
@@ -44,7 +44,7 @@ class m140209_132017_init extends Migration
         $this->createIndex('{{%user_recovery}}', '{{%user}}', 'id, recovery_token', true);
 
         $this->createTable('{{%profile}}', [
-            'user_id'        => $this->primaryKey(),
+            'user_id'        => $this->integer()->notNull(),
             'name'           => $this->string(255)->null(),
             'public_email'   => $this->string(255)->null(),
             'gravatar_email' => $this->string(255)->null(),
@@ -53,6 +53,8 @@ class m140209_132017_init extends Migration
             'website'        => $this->string(255)->null(),
             'bio'            => $this->text()->null(),
         ], $this->tableOptions);
+        
+        $this->addPrimaryKey('PRIMARY', '{{%profile}}', 'user_id');
 
         $this->addForeignKey('{{%fk_user_profile}}', '{{%profile}}', 'user_id', '{{%user}}', 'id', $this->cascade, $this->restrict);
     }


### PR DESCRIPTION
`$this->primaryKey()` is not appropriate for `user_id` field, because it add `AUTO_INCREMENT` into query.

https://github.com/yiisoft/yii2-framework/blob/master/db/QueryBuilder.php#L637

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | no