### PR TITLE
Order by most recent registration first (created_at DESC) by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix: Fixed migrations (dmeroff)
 - Fix #832: Fixed admin view file (thyseus)
+- Enh #839: Order by most recent registration first (created_at DESC) by default (thyseus)
 
 ## 0.9.11 [10 January 2017]
 

--- a/models/UserSearch.php
+++ b/models/UserSearch.php
@@ -82,6 +82,7 @@ class UserSearch extends Model
 
         $dataProvider = new ActiveDataProvider([
             'query' => $query,
+            'sort' => ['defaultOrder' => ['created_at' => SORT_DESC]],
         ]);
 
         if (!($this->load($params) && $this->validate())) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no

This seems to be a sane default setting. The probability is high that we want to deal with the most recent users first. Having an application with >10000 users this default settings would be nice.