### PR TITLE
Fix filters in model rules

### DIFF
--- a/models/LoginForm.php
+++ b/models/LoginForm.php
@@ -80,8 +80,8 @@ class LoginForm extends Model
     public function rules()
     {
         $rules = [
-            'requiredFields' => [['login'], 'required'],
             'loginTrim' => ['login', 'trim'],
+            'requiredFields' => [['login'], 'required'],
             'confirmationValidate' => [
                 'login',
                 function ($attribute) {

--- a/models/RecoveryForm.php
+++ b/models/RecoveryForm.php
@@ -85,7 +85,7 @@ class RecoveryForm extends Model
     public function rules()
     {
         return [
-            'emailTrim' => ['email', 'filter', 'filter' => 'trim'],
+            'emailTrim' => ['email', 'trim'],
             'emailRequired' => ['email', 'required'],
             'emailPattern' => ['email', 'email'],
             'passwordRequired' => ['password', 'required'],

--- a/models/RegistrationForm.php
+++ b/models/RegistrationForm.php
@@ -47,8 +47,8 @@ class RegistrationForm extends Model
 
         return [
             // username rules
+            'usernameTrim'     => ['username', 'trim'],
             'usernameLength'   => ['username', 'string', 'min' => 3, 'max' => 255],
-            'usernameTrim'     => ['username', 'filter', 'filter' => 'trim'],
             'usernamePattern'  => ['username', 'match', 'pattern' => $user::$usernameRegexp],
             'usernameRequired' => ['username', 'required'],
             'usernameUnique'   => [
@@ -58,7 +58,7 @@ class RegistrationForm extends Model
                 'message' => Yii::t('user', 'This username has already been taken')
             ],
             // email rules
-            'emailTrim'     => ['email', 'filter', 'filter' => 'trim'],
+            'emailTrim'     => ['email', 'trim'],
             'emailRequired' => ['email', 'required'],
             'emailPattern'  => ['email', 'email'],
             'emailUnique'   => [

--- a/models/SettingsForm.php
+++ b/models/SettingsForm.php
@@ -72,12 +72,12 @@ class SettingsForm extends Model
     public function rules()
     {
         return [
+            'usernameTrim' => ['username', 'trim'],
             'usernameRequired' => ['username', 'required'],
-            'usernameTrim' => ['username', 'filter', 'filter' => 'trim'],
             'usernameLength'   => ['username', 'string', 'min' => 3, 'max' => 255],
             'usernamePattern' => ['username', 'match', 'pattern' => '/^[-a-zA-Z0-9_\.@]+$/'],
+            'emailTrim' => ['email', 'trim'],
             'emailRequired' => ['email', 'required'],
-            'emailTrim' => ['email', 'filter', 'filter' => 'trim'],
             'emailPattern' => ['email', 'email'],
             'emailUsernameUnique' => [['email', 'username'], 'unique', 'when' => function ($model, $attribute) {
                 return $this->user->$attribute != $model->$attribute;

--- a/models/User.php
+++ b/models/User.php
@@ -224,6 +224,7 @@ class User extends ActiveRecord implements IdentityInterface
     {
         return [
             // username rules
+            'usernameTrim'     => ['username', 'trim'],
             'usernameRequired' => ['username', 'required', 'on' => ['register', 'create', 'connect', 'update']],
             'usernameMatch'    => ['username', 'match', 'pattern' => static::$usernameRegexp],
             'usernameLength'   => ['username', 'string', 'min' => 3, 'max' => 255],
@@ -232,9 +233,9 @@ class User extends ActiveRecord implements IdentityInterface
                 'unique',
                 'message' => \Yii::t('user', 'This username has already been taken')
             ],
-            'usernameTrim'     => ['username', 'trim'],
 
             // email rules
+            'emailTrim'     => ['email', 'trim'],
             'emailRequired' => ['email', 'required', 'on' => ['register', 'connect', 'create', 'update']],
             'emailPattern'  => ['email', 'email'],
             'emailLength'   => ['email', 'string', 'max' => 255],
@@ -243,7 +244,6 @@ class User extends ActiveRecord implements IdentityInterface
                 'unique',
                 'message' => \Yii::t('user', 'This email address has already been taken')
             ],
-            'emailTrim'     => ['email', 'trim'],
 
             // password rules
             'passwordRequired' => ['password', 'required', 'on' => ['register']],


### PR DESCRIPTION
From [documentation](https://github.com/yiisoft/yii2/blob/master/docs/guide/input-validation.md):
> The validation rules are evaluated in the order they are listed.

Filters like `trim` should be placed before the validation rules. Otherwise, they will not participate in the previous validation rules.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | no