### PR TITLE
SQL Server migrations fixes and improvements

### DIFF
--- a/migrations/Migration.php
+++ b/migrations/Migration.php
@@ -55,6 +55,25 @@ class Migration extends \yii\db\Migration
         }
     }
     
+    public function dropTable($table)
+    {
+        if ($this->dbType = 'sqlsrv') {
+            $this->dropTableConstraints($table);
+        }
+        return parent::dropTable($table);
+    }
+    
+    public function dropColumn($table, $column)
+    {
+        if ($this->dbType = 'sqlsrv') {
+            $this->dropColumnConstraints($table, $column);
+        }
+        return parent::dropColumn($table, $column);
+    }
+    
+    /*
+     *  Drops contratints and Indexes referencind a Table Column
+     */
     public function dropColumnConstraints($table, $column)
     {
         $table = Yii::$app->db->schema->getRawTableName($table);
@@ -64,12 +83,44 @@ class Migration extends \yii\db\Migration
                                     SELECT column_id 
                                     FROM sys.columns 
                                     WHERE object_id = object_id(:table)
-                                    and name = :column
+                                          AND name = :column
                                 )', [ ':table' => $table, ':column' => $column ]);
                                 
         $constraints = $cmd->queryAll();
         foreach ($constraints as $c) {
             $this->execute('ALTER TABLE '.Yii::$app->db->quoteTableName($table).' DROP CONSTRAINT '.Yii::$app->db->quoteColumnName($c['name']));
         }
+        
+        // checking for indexes
+        $cmd = Yii::$app->db->createCommand('SELECT ind.name FROM sys.indexes ind
+                                                INNER JOIN sys.index_columns ic 
+                                                    ON  ind.object_id = ic.object_id and ind.index_id = ic.index_id 
+                                                INNER JOIN sys.columns col 
+                                                    ON ic.object_id = col.object_id and ic.column_id = col.column_id 
+                                                WHERE ind.object_id = object_id(:table)
+                                                AND col.name = :column',
+                                [ ':table' => $table, ':column' => $column ]);
+                                
+        $indexes = $cmd->queryAll();
+        foreach ($indexes as $i) {
+            $this->dropIndex($i['name'],$table);
+        }
     }
+    
+    /*
+     *  Drops contratints referencing the Table
+     */
+    public function dropTableConstraints($table)
+    {
+        $table = Yii::$app->db->schema->getRawTableName($table);
+        $cmd = Yii::$app->db->createCommand('SELECT name, OBJECT_NAME(parent_object_id) as tbl FROM sys.foreign_keys
+                                WHERE referenced_object_id = object_id(:table)',
+                                [ ':table' => $table ]);
+        $constraints = $cmd->queryAll();
+        foreach ($constraints as $c) {
+            echo 'Dropping constrain: '.$c['name']."\n";
+            $this->execute('ALTER TABLE '.Yii::$app->db->quoteTableName($c['tbl']).' DROP CONSTRAINT '.Yii::$app->db->quoteColumnName($c['name']));
+        }
+    }
+    
 }

--- a/migrations/m140504_113157_update_tables.php
+++ b/migrations/m140504_113157_update_tables.php
@@ -53,6 +53,6 @@ class m140504_113157_update_tables extends Migration
         $this->addColumn('{{%user}}', 'confirmation_sent_at', $this->integer());
         $this->addColumn('{{%user}}', 'confirmation_token', $this->string(32));
         $this->createIndex('{{%user_confirmation}}', '{{%user}}', 'id, confirmation_token', true);
-        $this->createIndex('{{%user_recovery}', '{{%user}}', 'id, recovery_token', true);
+        $this->createIndex('{{%user_recovery}}', '{{%user}}', 'id, recovery_token', true);
     }
 }

--- a/migrations/m140830_171933_fix_ip_field.php
+++ b/migrations/m140830_171933_fix_ip_field.php
@@ -18,6 +18,10 @@ class m140830_171933_fix_ip_field extends Migration
 {
     public function up()
     {
+        if ($this->dbType == 'sqlsrv') {
+            // this is needed because we need to drop the constraint SQL created when renaming the column (?)
+            $this->dropColumnConstraints('{{%user}}','registration_ip');
+        }
         $this->alterColumn('{{%user}}', 'registration_ip', $this->bigInteger());
     }
 

--- a/migrations/m150623_212711_fix_username_notnull.php
+++ b/migrations/m150623_212711_fix_username_notnull.php
@@ -36,7 +36,7 @@ class m150623_212711_fix_username_notnull extends Migration
             if ($this->dbType == 'sqlsrv') {
                 $this->dropIndex('{{%user_unique_username}}', '{{%user}}');
             }
-            $this->alterColumn('{{%user}}', 'username', $this->string(255)->null());
+            $this->alterColumn('{{%user}}', 'username', $this->string(255), ' NULL');
             if ($this->dbType == 'sqlsrv') {
                 $this->createIndex('{{%user_unique_username}}', '{{%user}}', 'username', true);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | don't think so
| Fixed issues  | When doing migration up and down SQL server constraints tend to block operations on tables and columns. This should fix all the issues.