### PR TITLE
errorhandling recovery/reset token object

### DIFF
--- a/controllers/RecoveryController.php
+++ b/controllers/RecoveryController.php
@@ -148,6 +148,9 @@ class RecoveryController extends Controller
 
         /** @var Token $token */
         $token = $this->finder->findToken(['user_id' => $id, 'code' => $code, 'type' => Token::TYPE_RECOVERY])->one();
+        if (empty($token) || ! $token instanceof Token) {
+            throw new NotFoundHttpException();
+        }
         $event = $this->getResetPasswordEvent($token);
 
         $this->trigger(self::EVENT_BEFORE_TOKEN_VALIDATE, $event);


### PR DESCRIPTION
Just using an recovery token that does not exists you´ll get this internal error if you do not check for a Token object.

![yii2_user_recover_reset_errhandling](https://cloud.githubusercontent.com/assets/3859353/22697163/efae7732-ed50-11e6-9f12-8e28b9446bb3.png)


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no