### PR TITLE
ImpersonateUser fix

### DIFF
--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -121,7 +121,7 @@ $this->params['breadcrumbs'][] = $this->title;
                     }
                 },
                 'switch' => function ($url, $model) {
-                    if($model->id != Yii::$app->user->id && Yii::$app->getModule('user')->enableImpersonateUser) {
+                    if($model->isAdmin && $model->id != Yii::$app->user->id && Yii::$app->getModule('user')->enableImpersonateUser) {
                         return Html::a('<span class="glyphicon glyphicon-user"></span>', ['/user/admin/switch', 'id' => $model->id], [
                             'title' => Yii::t('user', 'Become this user'),
                             'data-confirm' => Yii::t('user', 'Are you sure you want to switch to this user for the rest of this Session?'),


### PR DESCRIPTION
>     * Tokens enclosed within curly brackets are treated as controller action IDs (also called *button names*
>     * in the context of action column). They will be replaced by the corresponding button rendering callbacks
>     * specified in [[buttons]]. For example, the token `{view}` will be replaced by the result of
>     * the callback `buttons['view']`. If a callback cannot be found, the token will be replaced with an empty string.


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes/no
| Fixed issues  | #890