### PR TITLE
"new static" to "Yii::createObject" fix

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -16,6 +16,7 @@ use dektrium\user\helpers\Password;
 use dektrium\user\Mailer;
 use dektrium\user\Module;
 use dektrium\user\traits\ModuleTrait;
+use Yii;
 use yii\base\NotSupportedException;
 use yii\behaviors\TimestampBehavior;
 use yii\db\ActiveRecord;
@@ -564,4 +565,11 @@ class User extends ActiveRecord implements IdentityInterface
     {
         throw new NotSupportedException('Method "' . __CLASS__ . '::' . __METHOD__ . '" is not implemented.');
     }
+    
+    /** @inheritdoc */
+    public static function instantiate($row)
+    {
+        return Yii::createObject(static::className());
+    }
+
 }


### PR DESCRIPTION
Result of finder (activeQuery createModels) is correct configure new model

Example usage (without fix not included/trigger `on beforeDelete`):

```
    'modules' => [
        'user' => [
            'class' => 'dektrium\user\Module',
            'enableRegistration' => false,
            'adminPermission' => 'administrateUser',
            'modelMap' => [
                'User' => [
                    'class' => 'dektrium\user\models\User',
                    'on ' . ActiveRecord::EVENT_AFTER_INSERT => function ($event) {
                        $id = $event->sender->getId();
                        $roleName = 'user';
                        $auth = Yii::$app->authManager;
                        if (!array_key_exists($roleName, $auth->getRolesByUser($id))) {
                            $userRole = $auth->getRole($roleName);
                            $auth->assign($userRole, $id);
                        }
                    },
                    'on ' . ActiveRecord::EVENT_BEFORE_DELETE => function ($event) {
                        $id = $event->sender->getId();
                        $auth = Yii::$app->authManager;
                        return $auth->revokeAll($id);
                    },
                ],
            ],
        ],
    ],
```



| Q             | A
| ------------- | ---
| Is bugfix?    | yes
