### PR TITLE
Fix: Update last_login_at when successfully logged in over oauth(#899)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- Fix: Update last_login_at when successfully logged in over oauth(#899)
+
 ## 0.9.12 [11 January 2017]
 
 - Fix: Fixed migrations (dmeroff)

--- a/controllers/SecurityController.php
+++ b/controllers/SecurityController.php
@@ -217,6 +217,7 @@ class SecurityController extends Controller
                 \Yii::$app->session->setFlash('danger', \Yii::t('user', 'Your account has been blocked.'));
                 $this->action->successUrl = Url::to(['/user/security/login']);
             } else {
+                $account->user->updateAttributes(['last_login_at' => time()]);
                 \Yii::$app->user->login($account->user, $this->module->rememberFor);
                 $this->action->successUrl = \Yii::$app->getUser()->getReturnUrl();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | #899 