### PR TITLE
Use `$this->db` instead of `Yii::$app->db` in migrations.

### DIFF
--- a/migrations/Migration.php
+++ b/migrations/Migration.php
@@ -57,8 +57,8 @@ class Migration extends \yii\db\Migration
     
     public function dropColumnConstraints($table, $column)
     {
-        $table = Yii::$app->db->schema->getRawTableName($table);
-        $cmd = Yii::$app->db->createCommand('SELECT name FROM sys.default_constraints
+        $table = $this->db->schema->getRawTableName($table);
+        $cmd = $this->db->createCommand('SELECT name FROM sys.default_constraints
                                 WHERE parent_object_id = object_id(:table)
                                 AND type = \'D\' AND parent_column_id = (
                                     SELECT column_id 
@@ -69,7 +69,7 @@ class Migration extends \yii\db\Migration
                                 
         $constraints = $cmd->queryAll();
         foreach ($constraints as $c) {
-            $this->execute('ALTER TABLE '.Yii::$app->db->quoteTableName($table).' DROP CONSTRAINT '.Yii::$app->db->quoteColumnName($c['name']));
+            $this->execute('ALTER TABLE '.$this->db->quoteTableName($table).' DROP CONSTRAINT '.$this->db->quoteColumnName($c['name']));
         }
     }
 }

--- a/migrations/m141222_110026_update_ip_field.php
+++ b/migrations/m141222_110026_update_ip_field.php
@@ -18,14 +18,14 @@ class m141222_110026_update_ip_field extends Migration
     {
         $users = (new Query())->from('{{%user}}')->select('id, registration_ip ip')->all();
 
-        $transaction = Yii::$app->db->beginTransaction();
+        $transaction = $this->db->beginTransaction();
         try {
             $this->alterColumn('{{%user}}', 'registration_ip', $this->string(45));
             foreach ($users as $user) {
                 if ($user['ip'] == null) {
                     continue;
                 }
-                Yii::$app->db->createCommand()->update('{{%user}}', [
+                $this->db->createCommand()->update('{{%user}}', [
                     'registration_ip' => long2ip($user['ip']),
                 ], 'id = ' . $user['id'])->execute();
             }
@@ -40,13 +40,13 @@ class m141222_110026_update_ip_field extends Migration
     {
         $users = (new Query())->from('{{%user}}')->select('id, registration_ip ip')->all();
 
-        $transaction = Yii::$app->db->beginTransaction();
+        $transaction = $this->db->beginTransaction();
         try {
             foreach ($users as $user) {
                 if ($user['ip'] == null) {
                     continue;
                 }
-                Yii::$app->db->createCommand()->update('{{%user}}', [
+                $this->db->createCommand()->update('{{%user}}', [
                     'registration_ip' => ip2long($user['ip'])
                 ], 'id = ' . $user['id'])->execute();
             }

--- a/migrations/m141222_110026_update_ip_field.php
+++ b/migrations/m141222_110026_update_ip_field.php
@@ -16,7 +16,7 @@ class m141222_110026_update_ip_field extends Migration
 {
     public function up()
     {
-        $users = (new Query())->from('{{%user}}')->select('id, registration_ip ip')->all();
+        $users = (new Query())->from('{{%user}}')->select('id, registration_ip ip')->all($this->db);
 
         $transaction = $this->db->beginTransaction();
         try {
@@ -38,7 +38,7 @@ class m141222_110026_update_ip_field extends Migration
 
     public function down()
     {
-        $users = (new Query())->from('{{%user}}')->select('id, registration_ip ip')->all();
+        $users = (new Query())->from('{{%user}}')->select('id, registration_ip ip')->all($this->db);
 
         $transaction = $this->db->beginTransaction();
         try {

--- a/migrations/m150614_103145_update_social_account_table.php
+++ b/migrations/m150614_103145_update_social_account_table.php
@@ -15,10 +15,10 @@ class m150614_103145_update_social_account_table extends Migration
 
         $accounts = (new Query())->from('{{%social_account}}')->select('id')->all();
 
-        $transaction = Yii::$app->db->beginTransaction();
+        $transaction = $this->db->beginTransaction();
         try {
             foreach ($accounts as $account) {
-                Yii::$app->db->createCommand()->update('{{%social_account}}', [
+                $this->db->createCommand()->update('{{%social_account}}', [
                     'created_at' => time(),
                 ], 'id = ' . $account['id'])->execute();
             }

--- a/migrations/m150614_103145_update_social_account_table.php
+++ b/migrations/m150614_103145_update_social_account_table.php
@@ -13,7 +13,7 @@ class m150614_103145_update_social_account_table extends Migration
         $this->addColumn('{{%social_account}}', 'username', $this->string()->null());
         $this->createIndex('{{%account_unique_code}}', '{{%social_account}}', 'code', true);
 
-        $accounts = (new Query())->from('{{%social_account}}')->select('id')->all();
+        $accounts = (new Query())->from('{{%social_account}}')->select('id')->all($this->db);
 
         $transaction = $this->db->beginTransaction();
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes

This is a small refactoring so migrations use the injected `Connection` object instead of using the global service locator (`Yii::$app`).