### PR TITLE
Not all timezones have hour offset, so we can not just divide offset

### DIFF
--- a/helpers/Timezone.php
+++ b/helpers/Timezone.php
@@ -31,10 +31,11 @@ class Timezone
 
         foreach ($timeZoneIdentifiers as $timeZone) {
             $date = new \DateTime('now', new \DateTimeZone($timeZone));
-            $offset = $date->getOffset() / 60 / 60;
+            $offset = $date->getOffset();
+            $tz = ($offset > 0 ? '+' : '-') . gmdate('H:i', abs($offset));
             $timeZones[] = [
                 'timezone' => $timeZone,
-                'name' => "{$timeZone} (UTC " . ($offset > 0 ? '+' : '') . "{$offset})",
+                'name' => "{$timeZone} (UTC " . "{$tz})",
                 'offset' => $offset
             ];
         }


### PR DESCRIPTION
In profile we have timezone select with names and offset of the timezone. Timezone hour offset converted from secconds to hour by  dividing to 3600. It's wrong. Because we have timezones with UTC +05:45, +12:45.
And as result: Pacific/Chatham (UTC +12.75). But expected:  Pacific/Chatham (UTC +12:45)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
