### PR TITLE
Removed PHP 7 syntax

### DIFF
--- a/models/UserSearch.php
+++ b/models/UserSearch.php
@@ -93,7 +93,7 @@ class UserSearch extends Model
             return $dataProvider;
         }
 
-        $table_name = $query->modelClass::tableName();
+        $table_name = $query->modelClass->tableName();
 
         if ($this->created_at !== null) {
             $date = strtotime($this->created_at);


### PR DESCRIPTION
Prior versions of PHP result in:
PHP Parse Error – yii\base\ErrorException
syntax error, unexpected '::' (T_PAAMAYIM_NEKUDOTAYIM)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | #921