### PR TITLE
$query->modelClass returns a String

### DIFF
--- a/models/UserSearch.php
+++ b/models/UserSearch.php
@@ -93,7 +93,7 @@ class UserSearch extends Model
             return $dataProvider;
         }
 
-        $table_name = $query->modelClass::tableName();
+        $table_name = \Yii::createObject(['class' => $query->modelClass])->tableName();
 
         if ($this->created_at !== null) {
             $date = strtotime($this->created_at);


### PR DESCRIPTION
http://www.yiiframework.com/doc-2.0/yii-db-activequerytrait.html#$modelClass-detail
modelClass is a string, not an object.

cannot apply ->tableName() to a string.
object must first be created from this string.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any