### PR TITLE
fixed information on resend password and recovery, related #856

### DIFF
--- a/models/RecoveryForm.php
+++ b/models/RecoveryForm.php
@@ -121,14 +121,22 @@ class RecoveryForm extends Model
             if (!$this->mailer->sendRecoveryMessage($user, $token)) {
                 return false;
             }
+
+            \Yii::$app->session->setFlash(
+                'info',
+                \Yii::t('user', 'An email has been sent with instructions for resetting your password')
+            );
+
+            return true;
+        } else {
+            \Yii::$app->session->setFlash(
+                'warning',
+                \Yii::t('user', 'Email could not been sent.')
+            );
+
+            return false;
         }
 
-        \Yii::$app->session->setFlash(
-            'info',
-            \Yii::t('user', 'An email has been sent with instructions for resetting your password')
-        );
-
-        return true;
     }
 
     /**

--- a/models/ResendForm.php
+++ b/models/ResendForm.php
@@ -101,15 +101,25 @@ class ResendForm extends Model
             ]);
             $token->save(false);
             $this->mailer->sendConfirmationMessage($user, $token);
+
+            \Yii::$app->session->setFlash(
+                'info',
+                \Yii::t(
+                    'user',
+                    'A message has been sent to your email address. It contains a confirmation link that you must click to complete registration.'
+                )
+            );
+        } else {
+            \Yii::$app->session->setFlash(
+                'warning',
+                \Yii::t(
+                    'user',
+                    'Could not send message to the given email address. Please register or resend password.'
+                )
+            );
+
         }
 
-        \Yii::$app->session->setFlash(
-            'info',
-            \Yii::t(
-                'user',
-                'A message has been sent to your email address. It contains a confirmation link that you must click to complete registration.'
-            )
-        );
 
         return true;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Fixed issues  | related #856 

Currently you can enter any e-mail address into recovery or resend password and you'll also get a success message even if the mail does not exists (eg. you've made a typo).

This PR adds a warning flash in these cases and outputs only success flashes when appropriate.