### PR TITLE
Do not update user if it is not logged

### DIFF
--- a/models/LoginForm.php
+++ b/models/LoginForm.php
@@ -142,8 +142,13 @@ class LoginForm extends Model
     public function login()
     {
         if ($this->validate() && $this->user) {
-            $this->user->updateAttributes(['last_login_at' => time()]);
-            return Yii::$app->getUser()->login($this->user, $this->rememberMe ? $this->module->rememberFor : 0);
+            
+            if($isLogged = Yii::$app->getUser()->login($this->user, $this->rememberMe ? $this->module->rememberFor : 0))
+            {
+                $this->user->updateAttributes(['last_login_at' => time()]);
+            }
+            
+            return $isLogged;
         }
 
         return false;


### PR DESCRIPTION
A user row is updated before really confirm user can log in.  All events attached to `\Yii\web\user::EVENT_BEFORE_LOGIN` can deny access to user. We can prevent this by changing the order of the code. 

For an example check #967

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | 