### PR TITLE
recovery with wrong email return success status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 
 # environment variable used in test suite
 env: TEST_ENVIRONMENT=travis
+dist: precise
 
 # faster builds on new travis setup not using sudo
 sudo: false

--- a/models/RecoveryForm.php
+++ b/models/RecoveryForm.php
@@ -121,7 +121,13 @@ class RecoveryForm extends Model
             if (!$this->mailer->sendRecoveryMessage($user, $token)) {
                 return false;
             }
-        }
+        } else {
+			\Yii::$app->session->setFlash(
+				'error',
+				\Yii::t('user', 'User is not found')
+			);
+        	return false;
+		}
 
         \Yii::$app->session->setFlash(
             'info',


### PR DESCRIPTION
I have some requests from users - they tryed to recovery user with wrong letter capitalization in email (PostgreSQL do not find them). Users saw success flash and wait mails. But no mail was send)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any