### PR TITLE
fix User::isAdmin to check admin access for model user instead of Yii::$app->user

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -122,7 +122,7 @@ class User extends ActiveRecord implements IdentityInterface
     {
         return
             (\Yii::$app->getAuthManager() && $this->module->adminPermission ?
-                \Yii::$app->user->can($this->module->adminPermission) : false)
+                \Yii::$app->authManager->checkAccess($this->id, $this->module->adminPermission) : false)
             || in_array($this->username, $this->module->admins);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | no