### PR TITLE
show resend password link

### DIFF
--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -117,7 +117,7 @@ $this->params['breadcrumbs'][] = $this->title;
             'template' => '{switch} {resend_password} {update} {delete}',
             'buttons' => [
                 'resend_password' => function ($url, $model, $key) {
-                    if (!$model->isAdmin) {
+                    if ($model->isAdmin) {
                         return '
                     <a data-method="POST" data-confirm="' . Yii::t('user', 'Are you sure?') . '" href="' . Url::to(['resend-password', 'id' => $model->id]) . '">
                     <span title="' . Yii::t('user', 'Generate and send new password to user') . '" class="glyphicon glyphicon-envelope">


### PR DESCRIPTION
resend password link was not visible bcz of typo mistake. 
It was allowing to non-admin ONLY. Now the link will be available for admin ONLY

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any