### PR TITLE
Support for Googles hosted domain parameter

### DIFF
--- a/clients/Google.php
+++ b/clients/Google.php
@@ -18,6 +18,23 @@ use yii\authclient\clients\Google as BaseGoogle;
  */
 class Google extends BaseGoogle implements ClientInterface
 {
+    /**
+     * @var string Hosted domain (hd) parameter sent to Google
+     */
+    public $hostedDomain;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildAuthUrl(array $params = [])
+    {
+        if ($this->hostedDomain) {
+            $params['hd'] = $this->hostedDomain;
+        }
+
+        return parent::buildAuthUrl($params);
+    }
+    
     /** @inheritdoc */
     public function getEmail()
     {


### PR DESCRIPTION
Adds support for the hosted domain (hd) parameter (https://developers.google.com/identity/protocols/OpenIDConnect). This allows to restrict the login to users of a specific G Suite domain.

Example configuration:
```php
'google' => [
    'class'        => 'dektrium\user\clients\Google',
    'clientId'     => 'CLIENT_ID',
    'clientSecret' => 'CLIENT_SECRET',
    'hostedDomain' => 'mydomain.com',
],
```

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Fixed issues  | 