### PR TITLE
BackendFilter controller validation bug

### DIFF
--- a/filters/BackendFilter.php
+++ b/filters/BackendFilter.php
@@ -25,7 +25,7 @@ class BackendFilter extends ActionFilter
     /**
      * @var array
      */
-    public $controllers = ['profile', 'recovery', 'registration', 'settings'];
+    public $controllers = ['profile', 'settings'];
 
     /**
      * @param \yii\base\Action $action


### PR DESCRIPTION
Controller validation bug on advanced template, recovery and registration controllers need to accessible before login.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  |no
| Breaks BC?    |no
| Fixed issues  | Security validation error