### PR TITLE
Php intl error on /user/show/<:id>

### DIFF
--- a/views/profile/show.php
+++ b/views/profile/show.php
@@ -47,7 +47,14 @@ $this->params['breadcrumbs'][] = $this->title;
                         </li>
                     <?php endif; ?>
                     <li>
-                        <i class="glyphicon glyphicon-time text-muted"></i> <?= Yii::t('user', 'Joined on {0, date}', $profile->user->created_at) ?>
+                        <i class="glyphicon glyphicon-time text-muted"></i> 
+                        <?php
+                        if (extension_loaded('intl')) {
+                            echo Yii::t('user', 'Joined on {0, date}', $profile->user->created_at);
+                        } else {
+                            echo "Joined on ".date('Y-m-d G:i:s', $profile->user->created_at);
+                        }
+                        ?>
                     </li>
                 </ul>
                 <?php if (!empty($profile->bio)): ?>


### PR DESCRIPTION
fixed profile show error when extension not loaded

| Q             | A
| ------------- | ---
| Is bugfix?    | yes